### PR TITLE
Add autoloadability via Bundler.require

### DIFF
--- a/lib/launchdarkly-server-sdk.rb
+++ b/lib/launchdarkly-server-sdk.rb
@@ -1,0 +1,1 @@
+require_relative "ldclient-rb"

--- a/spec/launchdarkly-server-sdk_spec.rb
+++ b/spec/launchdarkly-server-sdk_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+require "bundler"
+
+describe LaunchDarkly do
+  it "can be automatically loaded by Bundler.require" do
+    ldclient_loaded =
+      Bundler.with_clean_env do
+        Kernel.system("ruby", "-e", <<~RUBY)
+          require "bundler/setup"
+          require "bundler/inline"
+
+          gemfile do
+            gem "launchdarkly-server-sdk", path: "."
+          end
+
+          Bundler.require(:development)
+          abort unless $LOADED_FEATURES.any?(/ldclient-rb\.rb/)
+        RUBY
+      end
+
+    expect(ldclient_loaded).to be true
+  end
+end

--- a/spec/launchdarkly-server-sdk_spec.rb
+++ b/spec/launchdarkly-server-sdk_spec.rb
@@ -14,7 +14,7 @@ describe LaunchDarkly do
           end
 
           Bundler.require(:development)
-          abort unless $LOADED_FEATURES.any?(/ldclient-rb\.rb/)
+          abort unless $LOADED_FEATURES.any? { |file| file =~ /ldclient-rb\.rb/ }
         RUBY
       end
 

--- a/spec/launchdarkly-server-sdk_spec.rb
+++ b/spec/launchdarkly-server-sdk_spec.rb
@@ -5,17 +5,7 @@ describe LaunchDarkly do
   it "can be automatically loaded by Bundler.require" do
     ldclient_loaded =
       Bundler.with_clean_env do
-        Kernel.system("ruby", "-e", <<~RUBY)
-          require "bundler/setup"
-          require "bundler/inline"
-
-          gemfile do
-            gem "launchdarkly-server-sdk", path: "."
-          end
-
-          Bundler.require(:development)
-          abort unless $LOADED_FEATURES.any? { |file| file =~ /ldclient-rb\.rb/ }
-        RUBY
+        Kernel.system("ruby", "./spec/launchdarkly-server-sdk_spec_autoloadtest.rb")
       end
 
     expect(ldclient_loaded).to be true

--- a/spec/launchdarkly-server-sdk_spec_autoloadtest.rb
+++ b/spec/launchdarkly-server-sdk_spec_autoloadtest.rb
@@ -1,0 +1,9 @@
+require "bundler/setup"
+require "bundler/inline"
+
+gemfile do
+  gem "launchdarkly-server-sdk", path: "."
+end
+
+Bundler.require(:development)
+abort unless $LOADED_FEATURES.any? { |file| file =~ /ldclient-rb\.rb/ }


### PR DESCRIPTION
### Problem

I gotta say, it's not ideal that this repo, the gem name, and the require statement are all different. Currently, we have to do one of the following to load the gem:

#### Explicitly require the gem where we need it:
```ruby
# Gemfile
gem "launchdarkly-server-sdk"

# Usage
Bundler.require(:development)
LaunchDarkly::LDClient  # 💣

require "ldclient-rb"   # 😕
LaunchDarkly::LDClient  # ✅
```

#### Or, tell Bundler how to require it (if we are using Bundler.require or Rails):
```ruby
# Gemfile
gem "launchdarkly-server-sdk", require: "ldclient-rb" # 😕

# Usage
Bundler.require(:development)
LaunchDarkly::LDClient  # ✅
```

But what if there is a better way?...

### Solution

Bundler can automatically load gems if there is a conventionally named. First, it will try to [load a file matching the name of the gem](https://github.com/bundler/bundler/blob/v1.17.3/lib/bundler/runtime.rb#L76-L87). Then, it will rely on its naming [conventions](https://guides.rubygems.org/name-your-gem/).

This commit adds a file named `launchdarkly-server-sdk.rb` that simply requires `ldclient-rb.rb`, allowing for this feature to be used. This allows [Rails to automatically load the gem](https://github.com/rails/rails/blob/v5.2.3/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt#L20-L22) via `Bundler.require`. Hooray!!! 🍻

This allows Rails projects to simply add the following to their Gemfile:
```ruby
# Gemfile
gem "launchdarkly-server-sdk" # 😄

# Usage
Bundler.require(:development)
LaunchDarkly::LDClient  # ✅ 🎉🎉🎉
```

Hope this is helpful! 💜❤️🧡💛💚💙
