### PR TITLE
Only shutdown the Redis pool if it is owned by the SDK

### DIFF
--- a/lib/ldclient-rb/impl/integrations/redis_impl.rb
+++ b/lib/ldclient-rb/impl/integrations/redis_impl.rb
@@ -33,6 +33,7 @@ module LaunchDarkly
             @pool = opts[:pool] || ConnectionPool.new(size: max_connections) do
               ::Redis.new(@redis_opts)
             end
+            @pool_owned = !opts[:pool]
             @prefix = opts[:prefix] || LaunchDarkly::Integrations::Redis::default_prefix
             @logger = opts[:logger] || Config.default_logger
             @test_hook = opts[:test_hook]  # used for unit tests, deliberately undocumented
@@ -117,6 +118,8 @@ module LaunchDarkly
           end
 
           def stop
+            return unless @pool_owned
+
             if @stopped.make_true
               @pool.shutdown { |redis| redis.close }
             end

--- a/lib/ldclient-rb/impl/integrations/redis_impl.rb
+++ b/lib/ldclient-rb/impl/integrations/redis_impl.rb
@@ -33,7 +33,8 @@ module LaunchDarkly
             @pool = opts[:pool] || ConnectionPool.new(size: max_connections) do
               ::Redis.new(@redis_opts)
             end
-            @pool_owned = !opts[:pool]
+            # shutdown pool on close unless the client passed a custom pool and specified not to shutdown
+            @pool_shutdown_on_close = (!opts[:pool] || opts.fetch(:pool_shutdown_on_close, true))
             @prefix = opts[:prefix] || LaunchDarkly::Integrations::Redis::default_prefix
             @logger = opts[:logger] || Config.default_logger
             @test_hook = opts[:test_hook]  # used for unit tests, deliberately undocumented
@@ -118,9 +119,8 @@ module LaunchDarkly
           end
 
           def stop
-            return unless @pool_owned
-
             if @stopped.make_true
+              return unless @pool_shutdown_on_close
               @pool.shutdown { |redis| redis.close }
             end
           end

--- a/lib/ldclient-rb/integrations/redis.rb
+++ b/lib/ldclient-rb/integrations/redis.rb
@@ -45,6 +45,7 @@ module LaunchDarkly
       # @option opts [Integer] :expiration (15)  expiration time for the in-memory cache, in seconds; 0 for no local caching
       # @option opts [Integer] :capacity (1000)  maximum number of items in the cache
       # @option opts [Object] :pool  custom connection pool, if desired
+      # @option opts [Boolean] :pool_shutdown_on_close whether calling `close` should shutdown the custom connection pool.
       # @return [LaunchDarkly::Interfaces::FeatureStore]  a feature store object
       #
       def self.new_feature_store(opts)

--- a/lib/ldclient-rb/redis_store.rb
+++ b/lib/ldclient-rb/redis_store.rb
@@ -35,6 +35,7 @@ module LaunchDarkly
     # @option opts [Integer] :expiration  expiration time for the in-memory cache, in seconds; 0 for no local caching
     # @option opts [Integer] :capacity  maximum number of feature flags (or related objects) to cache locally
     # @option opts [Object] :pool  custom connection pool, if desired
+    # @option opts [Boolean] :pool_shutdown_on_close whether calling `close` should shutdown the custom connection pool.
     #
     def initialize(opts = {})
       core = LaunchDarkly::Impl::Integrations::Redis::RedisFeatureStoreCore.new(opts)


### PR DESCRIPTION
I'm not sure how to validate my changes against "all supported platform versions". I assume there is continuous integration that will run specs against all Ruby/RubyGems/Redis/etc. versions, but maybe I'm wrong. It would take hours for me to figure out how to do this locally.

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

My application needs to tightly control Redis connections because we have very high server concurrency so we need to be able to pass a Redis `ConnectionPool` directly to the SDK rather than having the SDK manage its own pool and have independent connections. However, we also use a preforking web server (Unicorn) and preload our application. Redis connections inside a `ConnectionPool` handle this gracefully, if the socket is shared to a forked child process the Redis client detects this and automatically reconnects. However we have to explicitly call `ld_client.stop` in `before_fork` and recreate the `ld_client` in the forked children. Doing so causes the SDK to shutdown the connection pool, which is irreversible. This change makes it so that the SDK only shuts down the pool if it was created by the SDK.

**Describe alternatives you've considered**

Our application currently implements an `UnstoppableConnectionPool` that ignores the `shutdown` method. We would prefer if this SDK did not shut down the pool if it is not "owned" by the SDK.

**Additional context**

This is not, or at least "ideally" is not, a breaking change. The Ruby Redis client does not ever actually need to be explicitly closed, the library handles closing connections when the client is garbage collected.