### PR TITLE
Log "unknown feature flag" as a warning instead of info

### DIFF
--- a/lib/ldclient-rb/ldclient.rb
+++ b/lib/ldclient-rb/ldclient.rb
@@ -393,7 +393,7 @@ module LaunchDarkly
       feature = @store.get(FEATURES, key)
 
       if feature.nil?
-        @config.logger.info { "[LDClient] Unknown feature flag \"#{key}\". Returning default value" }
+        @config.logger.warn { "[LDClient] Unknown feature flag \"#{key}\". Returning default value" }
         detail = error_result('FLAG_NOT_FOUND', default)
         @event_processor.add_event(event_factory.new_unknown_flag_event(key, user, default, detail.reason))
         return detail

--- a/lib/ldclient-rb/ldclient.rb
+++ b/lib/ldclient-rb/ldclient.rb
@@ -240,7 +240,7 @@ module LaunchDarkly
     #
     def identify(user)
       if !user || user[:key].nil?
-        @config.logger.warn("Identify called with nil user or nil user key!")
+        @config.logger.warn("[LDClient] Identify called with nil user or nil user key!")
         return
       end
       sanitize_user(user)
@@ -271,7 +271,7 @@ module LaunchDarkly
     #
     def track(event_name, user, data = nil, metric_value = nil)
       if !user || user[:key].nil?
-        @config.logger.warn("Track called with nil user or nil user key!")
+        @config.logger.warn("[LDClient] Track called with nil user or nil user key!")
         return
       end
       sanitize_user(user)
@@ -367,8 +367,8 @@ module LaunchDarkly
       if config.stream?
         StreamProcessor.new(sdk_key, config, requestor, diagnostic_accumulator)
       else
-        config.logger.info { "Disabling streaming API" }
-        config.logger.warn { "You should only disable the streaming API if instructed to do so by LaunchDarkly support" }
+        config.logger.info { "[LDClient] Disabling streaming API" }
+        config.logger.warn { "[LDClient] You should only disable the streaming API if instructed to do so by LaunchDarkly support" }
         PollingProcessor.new(config, requestor)
       end
     end


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**
We've been running LaunchDarkly logs with the `info` log level in all environments, so we can capture instances of "unknown feature flag" logs. The annoyance of working around the async event logs in our Rails console has reached the point that we'd really like to swap to the `warning` log level. However, that would mean we would not see instances of "unknown feature flag" logs. To us, those logs really make more sense as a warning (if not an error), thus, I'd like to propose changing it to `warn`.

I also noticed a few logs that are missing the `[LDClient]` prefix, so I added that. (I'm sure there are more missing.)

**Describe the solution you've provided**

Log "unknown feature flag" as a warning instead of info.

**Describe alternatives you've considered**

An alternative would be to use `get_flag_state_relaxed`, and handle our own default fallback, but that does not seem ideal for this sort of thing.

**Additional context**
