### PR TITLE
Remove warning

### DIFF
--- a/lib/ldclient-rb/impl/integrations/redis_impl.rb
+++ b/lib/ldclient-rb/impl/integrations/redis_impl.rb
@@ -115,10 +115,8 @@ module LaunchDarkly
           end
 
           def initialized_internal?
-            if Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('4.2.0')
-              with_connection { |redis| redis.exists?(inited_key) }
-            else
-              with_connection { |redis| redis.exists(inited_key) }
+            with_connection do |redis|
+              redis.respond_to?(:exists?) ? redis.exists?(inited_key) : redis.exists(inited_key)
             end
           end
 

--- a/lib/ldclient-rb/impl/integrations/redis_impl.rb
+++ b/lib/ldclient-rb/impl/integrations/redis_impl.rb
@@ -115,7 +115,11 @@ module LaunchDarkly
           end
 
           def initialized_internal?
-            with_connection { |redis| redis.exists(inited_key) }
+            if Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('4.2.0')
+              with_connection { |redis| redis.exists?(inited_key) }
+            else
+              with_connection { |redis| redis.exists(inited_key) }
+            end
           end
 
           def stop


### PR DESCRIPTION
`redis-rb 4.2.0` introduced the following warning 
```
`Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set `Redis.exists_returns_integer = false`, but this option will be removed in 5.0.
```

I drafted a PR [a few months ago](https://github.com/launchdarkly/ruby-server-sdk/pull/163) but never sat down to complete it, so here it is again.
I think this is the most accurate one, since the warning and the `exists?` [method was introduced in 4.2.2](https://github.com/redis/redis-rb/blob/7587668c1fe5c1f30387d80b5682a93678be40aa/CHANGELOG.md#420)

However, I can understand the conditional on a gem version is not welcomed, so as an alternative I can do:

```ruby
          def initialized_internal?
              with_connection do |redis|
                redis.respond_to?(:exists?) ? redis.exists?(inited_key) : redis.exists(inited_key)
              end
          end
```


**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
