### PR TITLE
Evaluate ERB syntax in FileDataSource

### DIFF
--- a/launchdarkly-server-sdk.gemspec
+++ b/launchdarkly-server-sdk.gemspec
@@ -31,6 +31,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop", "~> 0.9"
   spec.add_development_dependency "listen", "~> 3.3" # see file_data_source.rb
   spec.add_development_dependency "webrick", "~> 1.7"
+  spec.add_development_dependency "erb", "~> 2.2.3"
+
   # required by dynamodb
   spec.add_development_dependency "oga", "~> 2.2"
 


### PR DESCRIPTION
**Requirements**

- [x ] I have added test coverage for new or changed functionality
- [ x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

Hello. In transitioning to LaunchDarkly, it's essential we continue to support existing flags/environments. There are also situations where we need to spin up temporary environments and for that we'd like to avoid ephemeral LD environments. 

The file fall back works perfectly fine for these situations except when we want to toggle something via EVAR. Gems such as Feature [allow ERB syntax ](https://github.com/mgsnova/feature/blob/master/lib/feature/repository/yaml_repository.rb) in yaml to allow this. Many Rails tools I actually just assume i can use ERB syntax or at least rename a file `config.yml.erb`  

This PR adds ERB evaluation when ERB is available (i.e. most rails projects) allowing one to do something such as: 

```yaml
---
flagValues:
  my-feature-flag: <%= ENV['FEATURE_MY_FEATURE_FLAG'] == 'true' %>
```

I'm using this patch locally without issues and have added tests. It didn't feel right to add a configuration flag as not all languages have ERB and it's almost assumed in most Rails based configuration tools to have ERB be evaluated. I can contribute a documentation change if required for merging. 

Also if there's another way to accomplish this that I missed, please point me there. Not married to this approach but definitely need something for a true disconnected option. 
