### PR TITLE
use fast json parser

### DIFF
--- a/lib/ldclient-rb/stream.rb
+++ b/lib/ldclient-rb/stream.rb
@@ -84,14 +84,14 @@ module LaunchDarkly
       method = message.type
       @config.logger.debug { "[LDClient] Stream received #{method} message: #{message.data}" }
       if method == PUT
-        message = JSON.parse(message.data, symbolize_names: true)
+        message = FastJsonparser.parse(message.data, symbolize_keys: true)
         all_data = Impl::Model.make_all_store_data(message[:data])
         @feature_store.init(all_data)
         @initialized.make_true
         @config.logger.info { "[LDClient] Stream initialized" }
         @ready.set
       elsif method == PATCH
-        data = JSON.parse(message.data, symbolize_names: true)
+        data = FastJsonparser.parse(message.data, symbolize_keys: true)
         for kind in [FEATURES, SEGMENTS]
           key = key_for_path(kind, data[:path])
           if key
@@ -102,7 +102,7 @@ module LaunchDarkly
           end
         end
       elsif method == DELETE
-        data = JSON.parse(message.data, symbolize_names: true)
+        data = FastJsonparser.parse(message.data, symbolize_keys: true)
         for kind in [FEATURES, SEGMENTS]
           key = key_for_path(kind, data[:path])
           if key


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

We had to make this change to avoid strange malloc issues which seem related to LD's use of the JSON parser and our Falcon tool we use.
```
Corrupt value: 0x500007f88d6d8d00
(20876,0x700002995000) malloc: *** set a breakpoint in malloc_error_break to debug
[20542] - Worker 2 (PID: 20859) booted in 1.24s, phase: 0
[20542] - Worker 1 (PID: 20939) booted in 0.64s, phase: 0
```

**Describe the solution you've provided**
Using Fast JSON parser solved this issue, and also prevented Ruby using 99% of the CPU.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
