### PR TITLE
more specific error message around user hash

### DIFF
--- a/lib/ldclient-rb/ldclient.rb
+++ b/lib/ldclient-rb/ldclient.rb
@@ -435,8 +435,8 @@ module LaunchDarkly
         return Evaluator.error_result(EvaluationReason::ERROR_CLIENT_NOT_READY, default)
       end
 
-      unless user
-        @config.logger.error { "[LDClient] Must specify user" }
+      unless user && user.is_a?(Hash)
+        @config.logger.error { "[LDClient] Must specify user hash" }
         detail = Evaluator.error_result(EvaluationReason::ERROR_USER_NOT_SPECIFIED, default)
         return detail
       end


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

n/a

**Describe the solution you've provided**

Updating the user check to see if the passed user is a hash. I'm also updating the error message to specify that the user must be a hash, since the wording as it stands is very vague and not specific around what a "user" should be.

**Describe alternatives you've considered**

n/a

**Additional context**

n/a
