### PR TITLE
Add key to error log for invalid context during variation call for easier debugging

### DIFF
--- a/lib/ldclient-rb/ldclient.rb
+++ b/lib/ldclient-rb/ldclient.rb
@@ -387,7 +387,7 @@ module LaunchDarkly
 
       context = Impl::Context::make_context(context)
       unless context.valid?
-        @config.logger.error { "[LDClient] Context was invalid for flag evaluation (#{context.error}); returning default value" }
+        @config.logger.error { "[LDClient] Context was invalid for flag evaluation of key '#{key}' (#{context.error}); returning default value" }
         detail = Evaluator.error_result(EvaluationReason::ERROR_USER_NOT_SPECIFIED, default)
         return detail
       end

--- a/lib/ldclient-rb/ldclient.rb
+++ b/lib/ldclient-rb/ldclient.rb
@@ -387,7 +387,7 @@ module LaunchDarkly
 
       context = Impl::Context::make_context(context)
       unless context.valid?
-        @config.logger.error { "[LDClient] Context was invalid for flag evaluation of key '#{key}' (#{context.error}); returning default value" }
+        @config.logger.error { "[LDClient] Context was invalid for evaluation of flag '#{key}' (#{context.error}); returning default value" }
         detail = Evaluator.error_result(EvaluationReason::ERROR_USER_NOT_SPECIFIED, default)
         return detail
       end


### PR DESCRIPTION
This PR adds the evaluated key to the error log when the context is invalid to make it easier to track down where we might be passing in an invalid context. Happy to make changes/add a spec if you point me to the right place to add it!