### PR TITLE
[docs] Fix default_connect_timeout docs to match actual value.

### DIFF
--- a/lib/ldclient-rb/config.rb
+++ b/lib/ldclient-rb/config.rb
@@ -486,7 +486,7 @@ module LaunchDarkly
 
     #
     # The default value for {#connect_timeout}.
-    # @return [Float] 10
+    # @return [Float] 2
     #
     def self.default_connect_timeout
       2


### PR DESCRIPTION
Fixes default_connect_timeout documentation to match the value returned by the code.
