### PR TITLE
fix: Calling stop in ldd mode no longer raises an exception

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -10,9 +10,9 @@ runs:
   steps:
     - name: Build gemspec
       shell: bash
-      run: gem build ld-eventsource.gemspec
+      run: gem build launchdarkly-server-sdk.gemspec
 
     - name: Publish Library
       shell: bash
       if: ${{ inputs.dry_run == 'false' }}
-      run: gem push ld-eventsource-*.gem
+      run: gem push launchdarkly-server-sdk-*.gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the LaunchDarkly Ruby SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [7.3.1](https://github.com/launchdarkly/ruby-server-sdk/compare/7.3.0...7.3.1) (2023-12-26)
+
+
+### Bug Fixes
+
+* Calling stop in ldd mode no longer raises an exception ([#235](https://github.com/launchdarkly/ruby-server-sdk/issues/235)) ([eeb9906](https://github.com/launchdarkly/ruby-server-sdk/commit/eeb9906768f0519ac8d39def50226ed6bc8cb9ba))
+
 ## [8.0.0] - 2023-10-17
 The latest version of this SDK supports the ability to manage migrations or modernizations, using migration flags. You might use this functionality if you are optimizing queries, upgrading to new tech stacks, migrating from one database to another, or other similar technology changes. Migration flags are part of LaunchDarkly's Early Access Program. This feature is available to all LaunchDarkly customers but may undergo additional changes before it is finalized.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the LaunchDarkly Ruby SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [7.3.2](https://github.com/launchdarkly/ruby-server-sdk/compare/7.3.1...7.3.2) (2023-12-26)
+
+
+### Bug Fixes
+
+* Update missed version bump to LaunchDarkly::VERSION ([#239](https://github.com/launchdarkly/ruby-server-sdk/issues/239)) ([dc44559](https://github.com/launchdarkly/ruby-server-sdk/commit/dc44559a993f8cf2320532ef456421c103f87154))
+
 ## [7.3.1](https://github.com/launchdarkly/ruby-server-sdk/compare/7.3.0...7.3.1) (2023-12-26)
 
 

--- a/lib/ldclient-rb/ldclient.rb
+++ b/lib/ldclient-rb/ldclient.rb
@@ -93,6 +93,7 @@ module LaunchDarkly
 
       if @config.use_ldd?
         @config.logger.info { "[LDClient] Started LaunchDarkly Client in LDD mode" }
+        @data_source = NullUpdateProcessor.new
         return  # requestor and update processor are not used in this mode
       end
 

--- a/lib/ldclient-rb/version.rb
+++ b/lib/ldclient-rb/version.rb
@@ -1,3 +1,3 @@
 module LaunchDarkly
-  VERSION = "8.0.0"
+  VERSION = "8.0.0" # x-release-please-version
 end

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
       "bump-minor-pre-major": true,
       "versioning": "default",
       "include-component-in-tag": false,
-      "include-v-in-tag": false
+      "include-v-in-tag": false,
+      "extra-files": ["lib/ldclient-rb/version.rb"]
     }
   }
 }

--- a/spec/ldclient_spec.rb
+++ b/spec/ldclient_spec.rb
@@ -45,6 +45,23 @@ module LaunchDarkly
       end
     end
 
+    context "client can be stopped" do
+      it "when in online mode" do
+        client = subject.new("sdk-key", Config.new)
+        client.close()
+      end
+
+      it "when in offline mode" do
+        client = subject.new("sdk-key", Config.new(offline: true))
+        client.close()
+      end
+
+      it "when in ldd mode" do
+        client = subject.new("sdk-key", Config.new(use_ldd: true))
+        client.close()
+      end
+    end
+
     context "secure_mode_hash" do
       it "will return the expected value for a known message and secret" do
         ensure_close(subject.new("secret", test_config)) do |client|


### PR DESCRIPTION
- ci: Replace releaser with release please (#228)
- fix: Calling stop in ldd mode no longer raises an exception (#235)
