### PR TITLE
feat: Inline contexts for all evaluation events

### DIFF
--- a/contract-tests/service.rb
+++ b/contract-tests/service.rb
@@ -36,6 +36,7 @@ get '/' do
       'migrations',
       'event-sampling',
       'context-comparison',
+      'inline-context',
     ],
   }.to_json
 end

--- a/lib/ldclient-rb/events.rb
+++ b/lib/ldclient-rb/events.rb
@@ -485,7 +485,7 @@ module LaunchDarkly
         out[:variation] = event.variation unless event.variation.nil?
         out[:version] = event.version unless event.version.nil?
         out[:prereqOf] = event.prereq_of unless event.prereq_of.nil?
-        out[:contextKeys] = event.context.keys
+        out[:context] = @context_filter.filter(event.context)
         out[:reason] = event.reason unless event.reason.nil?
         out
 

--- a/spec/events_spec.rb
+++ b/spec/events_spec.rb
@@ -41,7 +41,7 @@ module LaunchDarkly
         output = flush_and_get_events(ep, sender)
         expect(output).to contain_exactly(
           eq(index_event(default_config, context)),
-          eq(feature_event(flag, context, 1, 'value')),
+          eq(feature_event(default_config, flag, context, 1, 'value')),
           include(:kind => "summary")
         )
       end
@@ -69,7 +69,7 @@ module LaunchDarkly
         output = flush_and_get_events(ep, sender)
         expect(output).to contain_exactly(
           eq(index_event(default_config, context)),
-          eq(feature_event(flag, context, 1, 'value'))
+          eq(feature_event(default_config, flag, context, 1, 'value'))
         )
       end
     end
@@ -83,7 +83,7 @@ module LaunchDarkly
         output = flush_and_get_events(ep, sender)
         expect(output).to contain_exactly(
           eq(index_event(config, context)),
-          eq(feature_event(flag, context, 1, 'value')),
+          eq(feature_event(config, flag, context, 1, 'value')),
           include(:kind => "summary")
         )
       end
@@ -98,7 +98,7 @@ module LaunchDarkly
         output = flush_and_get_events(ep, sender)
         expect(output).to contain_exactly(
           eq(index_event(config, context)),
-          eq(feature_event(flag, context, 1, 'value')),
+          eq(feature_event(config, flag, context, 1, 'value')),
           include(:kind => "summary")
         )
       end
@@ -142,7 +142,7 @@ module LaunchDarkly
         output = flush_and_get_events(ep, sender)
         expect(output).to contain_exactly(
           eq(index_event(default_config, context)),
-          eq(feature_event(flag, context, 1, 'value')),
+          eq(feature_event(default_config, flag, context, 1, 'value')),
           eq(debug_event(default_config, flag, context, 1, 'value')),
           include(:kind => "summary")
         )
@@ -207,8 +207,8 @@ module LaunchDarkly
         output = flush_and_get_events(ep, sender)
         expect(output).to contain_exactly(
           eq(index_event(default_config, context)),
-          eq(feature_event(flag1, context, 1, 'value', starting_timestamp)),
-          eq(feature_event(flag2, context, 1, 'value', starting_timestamp + 1)),
+          eq(feature_event(default_config, flag1, context, 1, 'value', starting_timestamp)),
+          eq(feature_event(default_config, flag2, context, 1, 'value', starting_timestamp + 1)),
           include(:kind => "summary")
         )
       end
@@ -624,6 +624,7 @@ module LaunchDarkly
     end
 
     #
+    # @param config [Config]
     # @param flag [Hash]
     # @param context [LDContext]
     # @param variation [Integer]
@@ -631,11 +632,12 @@ module LaunchDarkly
     # @param timestamp [Integer]
     # @return [Hash]
     #
-    def feature_event(flag, context, variation, value, timestamp = starting_timestamp)
+    def feature_event(config, flag, context, variation, value, timestamp = starting_timestamp)
+      context_filter = Impl::ContextFilter.new(config.all_attributes_private, config.private_attributes)
       out = {
         kind: 'feature',
         creationDate: timestamp,
-        contextKeys: context.keys,
+        context: context_filter.filter(context),
         key: flag[:key],
         variation: variation,
         version: flag[:version],


### PR DESCRIPTION
The v4 event schema is being broadened to accept full context payloads instead of only the context kind/key pairings.

There are several additional commits coming to address the updated spec, so these PRs are going to be merged into a feature branch.