### PR TITLE
build: adding provenance generation to ruby release-please workflow

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -4,6 +4,10 @@ inputs:
   dry_run:
     description: 'Is this a dry run. If so no package will be published.'
     required: true
+outputs:
+  gem-hash:
+    description: "base64-encoded sha256 hashes of distribution files"
+    value: ${{ steps.gem-hash.outputs.gem-hash }}
 
 runs:
   using: composite
@@ -11,6 +15,12 @@ runs:
     - name: Build gemspec
       shell: bash
       run: gem build launchdarkly-server-sdk.gemspec
+
+    - name: Hash gem for provenance
+      id: gem-hash
+      shell: bash 
+      run: |
+        echo "gem-hash=$(sha256sum launchdarkly-server-sdk-*.gem | base64 -w0)" >> "$GITHUB_OUTPUT"
 
     - name: Publish Library
       shell: bash

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -47,6 +47,5 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.7.0
     with:
       base64-subjects: "${{ needs.build-publish.outputs.gem-hash }}"
-      upload-assets: true
-      upload-tag-name: TBD
+      upload-assets: ${{ !inputs.dry_run }}
         

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -14,6 +14,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    outputs:
+      gem-hash: ${{ steps.publish.outputs.gem-hash}}
     steps:
       - uses: actions/checkout@v4
 
@@ -34,3 +36,17 @@ jobs:
         uses: ./.github/actions/publish
         with:
           dry_run: ${{ inputs.dry_run }}
+
+  release-provenance:
+    needs: [ 'build-publish' ]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.7.0
+    with:
+      base64-subjects: "${{ needs.build-publish.outputs.gem-hash }}"
+      upload-assets: true
+      upload-tag-name: TBD
+        

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,10 @@ jobs:
       id-token: write # Needed if using OIDC to get release secrets.
       contents: write # Contents and pull-requests are for release-please to make releases.
       pull-requests: write
+    outputs:
+      release-created: ${{ steps.release.outputs.release_created }}
+      upload-tag-name: ${{ steps.release.outputs.tag_name }}
+      gem-hash: ${{ steps.publish.outputs.gem-hash}}
     steps:
       - uses: google-github-actions/release-please-action@v3
         id: release
@@ -41,6 +45,7 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
 
       - uses: ./.github/actions/publish
+        id: publish
         if: ${{ steps.release.outputs.releases_created }}
         with:
           dry_run: false
@@ -49,3 +54,17 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
         with:
           token: ${{secrets.GITHUB_TOKEN}}
+
+  release-provenance:
+    needs: [ 'release-package' ]
+    if: ${{ needs.release-package.outputs.release-created }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.7.0
+    with:
+      base64-subjects: "${{ needs.release-package.outputs.gem-hash }}"
+      upload-assets: true
+      upload-tag-name: ${{ needs.release-package.outputs.upload-tag-name }}

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,0 +1,28 @@
+## Verifying SDK build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+
+As part of [SLSA requirements for level 3 compliance](https://slsa.dev/spec/v1.0/requirements), LaunchDarkly publishes provenance about our SDK package builds using [GitHub's generic SLSA3 provenance generator](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#generation-of-slsa3-provenance-for-arbitrary-projects) for distribution alongside our packages. These attestations are available for download from the GitHub release page for the release version under Assets > `multiple-provenance.intoto.jsonl`.
+
+To verify SLSA provenance attestations, we recommend using [slsa-verifier](https://github.com/slsa-framework/slsa-verifier). Example usage for verifying SDK packages is included below:
+
+```
+# Download gem
+$ gem fetch launchdarkly-server-sdk
+
+# Download provenance from Github release
+$ curl --location -O \
+  https://github.com/launchdarkly/ruby-server-sdk/releases/download/VERSION/multiple.intoto.jsonl
+
+# Run slsa-verifier to verify provenance against package artifacts 
+$ slsa-verifier verify-artifact \
+--provenance-path multiple-provenance.intoto.jsonl \
+--source-uri github.com/launchdarkly/ruby-server-sdk \
+launchdarkly-server-sdk-VERSION.gem
+
+TBD OUTPUT
+```
+
+Alternatively, to verify the provenance manually, the SLSA framework specifies [recommendations for verifying build artifacts](https://slsa.dev/spec/v1.0/verifying-artifacts) in their documentation.
+
+**Note:** These instructions do not apply when building our SDKs from source. 

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -19,8 +19,6 @@ $ slsa-verifier verify-artifact \
 --provenance-path multiple-provenance.intoto.jsonl \
 --source-uri github.com/launchdarkly/ruby-server-sdk \
 launchdarkly-server-sdk-VERSION.gem
-
-TBD OUTPUT
 ```
 
 Alternatively, to verify the provenance manually, the SLSA framework specifies [recommendations for verifying build artifacts](https://slsa.dev/spec/v1.0/verifying-artifacts) in their documentation.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ Contributing
 ------------
  
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this SDK.
- 
+
+Verifying SDK build provenance with the SLSA framework
+------------
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+
 About LaunchDarkly
 -----------
  


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Using Github SLSA generator to generate build provenance for ruby-server-sdk

Implementation based off of previous SDK SLSA integrations with release-please

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
