### PR TITLE
chore: Remove frames.html from generated doc

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,3 @@
-
 ifeq ($(LD_RELEASE_VERSION),)
 TITLE=LaunchDarkly Ruby SDK
 else
@@ -20,6 +19,7 @@ html: dependencies
 		lib/**/*.rb \
 		lib/**/**/*.rb \
 		lib/**/**/**/*.rb
+	rm -f build/html/frames.html
 
 dependencies:
 	gem install --conservative yard


### PR DESCRIPTION
The documentation generated from `yard` creates a [frames.html][1] file.
This file is susceptible to XSS attacks.

Additionally, this page can act as an open redirect (e.g.
https://launchdarkly.github.io/ruby-server-sdk/frames.html#!////example.com).

To remediate this problem, we are going to simply remove the generate
frames.html file. This file was created to [support classical frameset
views for the docs][2], which we have no need to support.

[1]: https://github.com/lsegal/yard/blob/2d197a381c5d4cc5c55b2c60fff992b31c986361/templates/default/fulldoc/html/frames.erb
[2]: https://github.com/lsegal/yard/commit/dc0fcb457627dcf32b1ad710164cbf7ed751ec03
