### PR TITLE
fix: Do not assume Rails.logger exists simply because it responds to the method

### DIFF
--- a/lib/ldclient-rb/config.rb
+++ b/lib/ldclient-rb/config.rb
@@ -458,7 +458,7 @@ module LaunchDarkly
     # @return [Logger] the Rails logger if in Rails, or a default Logger at WARN level otherwise
     #
     def self.default_logger
-      if defined?(Rails) && Rails.respond_to?(:logger)
+      if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
         Rails.logger
       else
         log = ::Logger.new($stdout)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -49,6 +49,11 @@ module LaunchDarkly
         stub_const("Rails", rails)
         expect(subject.default_logger).to eq :logger
       end
+      it "uses logger if Rails logger is nil" do
+        rails = instance_double("Rails", logger: nil)
+        stub_const("Rails", rails)
+        expect(subject.default_logger).to be_an_instance_of Logger
+      end
       it "Uses logger if Rails is not available" do
         expect(subject.default_logger).to be_an_instance_of Logger
       end


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

I did not validate it against all platform versions, but rather than use something like `present?` or `try` or `&.` I just used the ruby idiom for checking nil/false by using the object at the end, like `&& object` 

Have you considered putting that last requirement into the CI's hands so that it might become unnecessary?

**Related issues**

None that I am aware of. 

**Describe the solution you've provided**

The code previously checked that Rails responded to `logger` and if it did, assumes there is actually a logger present, which is not always the case. This leaves LD with a `nil` value for `logger` which causes the application to crash. 

**Describe alternatives you've considered**

I did not consider any alternatives. 

**Additional context**

None. 
