### PR TITLE
fix: Remove invalid prereq `check_variation_range` check (#261)

### DIFF
--- a/lib/ldclient-rb/impl/model/feature_flag.rb
+++ b/lib/ldclient-rb/impl/model/feature_flag.rb
@@ -37,7 +37,7 @@ module LaunchDarkly
           @off_variation = data[:offVariation]
           check_variation_range(self, errors, @off_variation, "off variation")
           @prerequisites = (data[:prerequisites] || []).map do |prereq_data|
-            Prerequisite.new(prereq_data, self, errors)
+            Prerequisite.new(prereq_data, self)
           end
           @targets = (data[:targets] || []).map do |target_data|
             Target.new(target_data, self, errors)
@@ -118,13 +118,12 @@ module LaunchDarkly
       end
 
       class Prerequisite
-        def initialize(data, flag, errors_out = nil)
+        def initialize(data, flag)
           @data = data
           @key = data[:key]
           @variation = data[:variation]
           @failure_result = EvaluatorHelpers.evaluation_detail_for_off_variation(flag,
             EvaluationReason::prerequisite_failed(@key))
-          check_variation_range(flag, errors_out, @variation, "prerequisite")
         end
 
         # @return [Hash]


### PR DESCRIPTION
When parsing flag payload information, the SDK attempts to pre-check several failure conditions. One of those conditions was to ensure that a provided prereq has a valid variation index.

However, the system cannot actually perform this check at parse time since the prerequisite flag might not have been parsed yet.

As this check served only as a nice to have, I have removed it and added a test verifying the prereq behavior still operates as expected.

Fixes #260