### PR TITLE
fix: Remove outdated deprecation notice

### DIFF
--- a/lib/ldclient-rb/context.rb
+++ b/lib/ldclient-rb/context.rb
@@ -377,8 +377,6 @@ module LaunchDarkly
     # {https://docs.launchdarkly.com/sdk/features/user-config SDK
     # documentation}.
     #
-    # @deprecated The old user format will be removed in 8.0.0. Please use the new context specific format.
-    #
     # @param data [Hash]
     # @return [LDContext]
     #


### PR DESCRIPTION
Legacy user format was indeed removed in v8.0.0. However, this
deprecation warning was missed causing confusion for customers.
