### PR TITLE
fix: Modify data kind constants to avoid Process.warmup rehash

### DIFF
--- a/lib/ldclient-rb/in_memory_store.rb
+++ b/lib/ldclient-rb/in_memory_store.rb
@@ -11,17 +11,10 @@ module LaunchDarkly
   # to ensure data consistency during non-atomic updates.
 
   # @private
-  FEATURES = {
-    namespace: "features",
-    priority: 1,  # that is, features should be stored after segments
-    get_dependency_keys: lambda { |flag| (flag[:prerequisites] || []).map { |p| p[:key] } },
-  }.freeze
+  FEATURES = Impl::DataStore::DataKind.new(namespace: "features", priority: 1).freeze
 
   # @private
-  SEGMENTS = {
-    namespace: "segments",
-    priority: 0,
-  }.freeze
+  SEGMENTS = Impl::DataStore::DataKind.new(namespace: "segments", priority: 0).freeze
 
   # @private
   ALL_KINDS = [FEATURES, SEGMENTS].freeze


### PR DESCRIPTION
The data stores in the SDK have to deal with multiple types of data --
features (or flags) and segments. These types have long been simple
hashes in our SDK, with one defining an optional lambda property.

With Ruby 3.3 and the introduction of `Process.warmup`, we have seen an
issue where, after warmup, the in memory store needs a `rehash` method
call before these kind constants can be used reliably to access the
store.

To combat this, I am moving these kinds into a class. This class as
explicit hash key behaviors, so theoretically shouldn't have this
problem Local testing has shown this to be the case.

This class is also given a dictionary interface to maintain compliance
with the existing implementation. While people should not be relying on
these constants explicitly, they do flow through the system in ways that
might make their signatures somewhat public.
