### PR TITLE
fix: Allow gem to be installed from source

### DIFF
--- a/launchdarkly-server-sdk.gemspec
+++ b/launchdarkly-server-sdk.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/launchdarkly/ruby-server-sdk"
   spec.license       = "Apache-2.0"
 
-  spec.files         = FileList["lib/**/*", "README.md", "LICENSE.txt"]
+  spec.files         = Dir["lib/**/*.rb", "README.md", "LICENSE.txt"]
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 3.0.0"

--- a/launchdarkly-server-sdk.gemspec
+++ b/launchdarkly-server-sdk.gemspec
@@ -3,7 +3,6 @@
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "ldclient-rb/version"
-require "rake"
 
 # rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |spec|


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

In #303 I was asked to install the gem in my Gemfile from source to confirm a bug fix but I encountered two `bundle install` errors that prevented that. I had to make these changes to be able to successfully install from source.

**Describe the solution you've provided**

Do not depend on rake in the gemspec as there is no need too. Replacing Rake's `FileList` with Ruby's `Dir` is a common use for the affected line and can be seen in many popular gemspecs.

**Describe alternatives you've considered**

I didn't consider any alternatives because it would be best to not depend on an unnecessary dependency (e.g. rake) in the gemspec file. This also follows what is commonly done in other Ruby gems so it's well supported.
