### PR TITLE
fix: Provide thread names whenever possible

### DIFF
--- a/launchdarkly-server-sdk.gemspec
+++ b/launchdarkly-server-sdk.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "semantic", "~> 1.6"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.1"
-  spec.add_runtime_dependency "ld-eventsource", "2.2.2"
+  spec.add_runtime_dependency "ld-eventsource", "2.2.3"
   spec.add_runtime_dependency "observer", "~> 0.1.2"
   spec.add_runtime_dependency "zlib", "~> 3.1" unless RUBY_PLATFORM == "java"
   # Please keep ld-eventsource dependency as an exact version so that bugfixes to

--- a/lib/ldclient-rb/events.rb
+++ b/lib/ldclient-rb/events.rb
@@ -243,10 +243,10 @@ module LaunchDarkly
       @events_in_last_batch = 0
 
       outbox = EventBuffer.new(config.capacity, config.logger)
-      flush_workers = NonBlockingThreadPool.new(MAX_FLUSH_WORKERS, 'EventDispatcher/FlushWorkers')
+      flush_workers = NonBlockingThreadPool.new(MAX_FLUSH_WORKERS, 'LD/EventDispatcher/FlushWorkers')
 
       if !@diagnostic_accumulator.nil?
-        diagnostic_event_workers = NonBlockingThreadPool.new(1, 'EventDispatcher/DiagnosticEventWorkers')
+        diagnostic_event_workers = NonBlockingThreadPool.new(1, 'LD/EventDispatcher/DiagnosticEventWorkers')
         init_event = @diagnostic_accumulator.create_init_event(config)
         send_diagnostic_event(init_event, diagnostic_event_workers)
       else

--- a/lib/ldclient-rb/events.rb
+++ b/lib/ldclient-rb/events.rb
@@ -243,10 +243,10 @@ module LaunchDarkly
       @events_in_last_batch = 0
 
       outbox = EventBuffer.new(config.capacity, config.logger)
-      flush_workers = NonBlockingThreadPool.new(MAX_FLUSH_WORKERS)
+      flush_workers = NonBlockingThreadPool.new(MAX_FLUSH_WORKERS, 'EventDispatcher/FlushWorkers')
 
       if !@diagnostic_accumulator.nil?
-        diagnostic_event_workers = NonBlockingThreadPool.new(1)
+        diagnostic_event_workers = NonBlockingThreadPool.new(1, 'EventDispatcher/DiagnosticEventWorkers')
         init_event = @diagnostic_accumulator.create_init_event(config)
         send_diagnostic_event(init_event, diagnostic_event_workers)
       else

--- a/lib/ldclient-rb/events.rb
+++ b/lib/ldclient-rb/events.rb
@@ -253,7 +253,7 @@ module LaunchDarkly
         diagnostic_event_workers = nil
       end
 
-      Thread.new { main_loop(inbox, outbox, flush_workers, diagnostic_event_workers) }
+      Thread.new { main_loop(inbox, outbox, flush_workers, diagnostic_event_workers) }.name = "LD/EventDispatcher#main_loop"
     end
 
     private

--- a/lib/ldclient-rb/impl/big_segments.rb
+++ b/lib/ldclient-rb/impl/big_segments.rb
@@ -24,7 +24,7 @@ module LaunchDarkly
 
         unless @store.nil?
           @cache = ExpiringCache.new(big_segments_config.context_cache_size, big_segments_config.context_cache_time)
-          @poll_worker = RepeatingTask.new(big_segments_config.status_poll_interval, 0, -> { poll_store_and_update_status }, logger)
+          @poll_worker = RepeatingTask.new(big_segments_config.status_poll_interval, 0, -> { poll_store_and_update_status }, logger, 'LD/BigSegments#status')
           @poll_worker.start
         end
       end

--- a/lib/ldclient-rb/impl/integrations/file_data_source.rb
+++ b/lib/ldclient-rb/impl/integrations/file_data_source.rb
@@ -216,7 +216,7 @@ module LaunchDarkly
                 end
               end
             end
-            @thread.name = "LD/Impl/Integrations/FileDataSourceImpl/FileDataSourcePoller"
+            @thread.name = "LD/FileDataSource"
           end
 
           def stop

--- a/lib/ldclient-rb/impl/integrations/file_data_source.rb
+++ b/lib/ldclient-rb/impl/integrations/file_data_source.rb
@@ -216,6 +216,7 @@ module LaunchDarkly
                 end
               end
             end
+            @thread.name = "LD/Impl/Integrations/FileDataSourceImpl/FileDataSourcePoller"
           end
 
           def stop

--- a/lib/ldclient-rb/impl/migrations/migrator.rb
+++ b/lib/ldclient-rb/impl/migrations/migrator.rb
@@ -188,6 +188,9 @@ module LaunchDarkly
             auth_handler = Thread.new { authoritative_result = authoritative.run }
             nonauth_handler = Thread.new { nonauthoritative_result = nonauthoritative.run }
 
+            auth_handler.name = "LD/Impl/Migrations/Migrator/auth_handler"
+            nonauth_handler.name = "LD/Impl/Migrations/Migrator/nonauth_handler"
+
             auth_handler.join()
             nonauth_handler.join()
           when LaunchDarkly::Migrations::MigratorBuilder::EXECUTION_RANDOM && @sampler.sample(2)

--- a/lib/ldclient-rb/impl/migrations/migrator.rb
+++ b/lib/ldclient-rb/impl/migrations/migrator.rb
@@ -188,8 +188,8 @@ module LaunchDarkly
             auth_handler = Thread.new { authoritative_result = authoritative.run }
             nonauth_handler = Thread.new { nonauthoritative_result = nonauthoritative.run }
 
-            auth_handler.name = "LD/Impl/Migrations/Migrator/auth_handler"
-            nonauth_handler.name = "LD/Impl/Migrations/Migrator/nonauth_handler"
+            auth_handler.name = "LD/Migrator#auth_handler"
+            nonauth_handler.name = "LD/Migrator#nonauth_handler"
 
             auth_handler.join()
             nonauth_handler.join()

--- a/lib/ldclient-rb/impl/repeating_task.rb
+++ b/lib/ldclient-rb/impl/repeating_task.rb
@@ -30,6 +30,8 @@ module LaunchDarkly
               sleep(delta)
             end
           end
+        end.tap do |worker|
+          worker.name = "LD/Impl/RepeatingTask"
         end
       end
 

--- a/lib/ldclient-rb/impl/repeating_task.rb
+++ b/lib/ldclient-rb/impl/repeating_task.rb
@@ -5,13 +5,16 @@ require "concurrent/atomics"
 module LaunchDarkly
   module Impl
     class RepeatingTask
-      def initialize(interval, start_delay, task, logger)
+      attr_reader :name
+
+      def initialize(interval, start_delay, task, logger, name)
         @interval = interval
         @start_delay = start_delay
         @task = task
         @logger = logger
         @stopped = Concurrent::AtomicBoolean.new(false)
         @worker = nil
+        @name = name
       end
 
       def start
@@ -30,9 +33,9 @@ module LaunchDarkly
               sleep(delta)
             end
           end
-        end.tap do |worker|
-          worker.name = "LD/Impl/RepeatingTask"
         end
+
+        @worker.name = @name
       end
 
       def stop

--- a/lib/ldclient-rb/impl/store_client_wrapper.rb
+++ b/lib/ldclient-rb/impl/store_client_wrapper.rb
@@ -99,7 +99,7 @@ module LaunchDarkly
 
         @logger.warn("Detected persistent store unavailability; updates will be cached until it recovers.")
 
-        task = Impl::RepeatingTask.new(0.5, 0, -> { self.check_availability }, @logger)
+        task = Impl::RepeatingTask.new(0.5, 0, -> { self.check_availability }, @logger, 'LD/StoreWrapper#check_availability')
 
         @mutex.synchronize do
           @poller = task

--- a/lib/ldclient-rb/non_blocking_thread_pool.rb
+++ b/lib/ldclient-rb/non_blocking_thread_pool.rb
@@ -8,9 +8,9 @@ module LaunchDarkly
   # than blocking. Also provides a way to wait for all jobs to finish without shutting down.
   # @private
   class NonBlockingThreadPool
-    def initialize(capacity)
+    def initialize(capacity, name = 'LD/NonBlockingThreadPool')
       @capacity = capacity
-      @pool = Concurrent::FixedThreadPool.new(capacity, name: "LD/NonBlockingThreadPool")
+      @pool = Concurrent::FixedThreadPool.new(capacity, name: name)
       @semaphore = Concurrent::Semaphore.new(capacity)
     end
 

--- a/lib/ldclient-rb/non_blocking_thread_pool.rb
+++ b/lib/ldclient-rb/non_blocking_thread_pool.rb
@@ -10,7 +10,7 @@ module LaunchDarkly
   class NonBlockingThreadPool
     def initialize(capacity)
       @capacity = capacity
-      @pool = Concurrent::FixedThreadPool.new(capacity)
+      @pool = Concurrent::FixedThreadPool.new(capacity, name: "LD/NonBlockingThreadPool")
       @semaphore = Concurrent::Semaphore.new(capacity)
     end
 

--- a/lib/ldclient-rb/polling.rb
+++ b/lib/ldclient-rb/polling.rb
@@ -13,7 +13,7 @@ module LaunchDarkly
       @initialized = Concurrent::AtomicBoolean.new(false)
       @started = Concurrent::AtomicBoolean.new(false)
       @ready = Concurrent::Event.new
-      @task = Impl::RepeatingTask.new(@config.poll_interval, 0, -> { self.poll }, @config.logger)
+      @task = Impl::RepeatingTask.new(@config.poll_interval, 0, -> { self.poll }, @config.logger, 'LD/PollingDataSource')
     end
 
     def initialized?

--- a/spec/impl/repeating_task_spec.rb
+++ b/spec/impl/repeating_task_spec.rb
@@ -11,9 +11,17 @@ module LaunchDarkly
         double.as_null_object
       end
 
+      it "can name the task" do
+        signal = Concurrent::Event.new
+        task = RepeatingTask.new(0.01, 0, -> { signal.set }, null_logger, "Junie B.")
+
+        expect(task.name).to eq("Junie B.")
+        task.stop
+      end
+
       it "does not start when created" do
         signal = Concurrent::Event.new
-        task = RepeatingTask.new(0.01, 0, -> { signal.set }, null_logger)
+        task = RepeatingTask.new(0.01, 0, -> { signal.set }, null_logger, "test")
         begin
           expect(signal.wait(0.1)).to be false
         ensure
@@ -23,7 +31,7 @@ module LaunchDarkly
 
       it "executes until stopped" do
         queue = Queue.new
-        task = RepeatingTask.new(0.1, 0, -> { queue << Time.now }, null_logger)
+        task = RepeatingTask.new(0.1, 0, -> { queue << Time.now }, null_logger, "test")
         begin
           last = nil
           task.start
@@ -62,7 +70,7 @@ module LaunchDarkly
               stopped.set
             end
           },
-          null_logger)
+          null_logger, "test")
         begin
           task.start
           expect(stopped.wait(0.1)).to be true


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

There are no related issues at the time of filing.

**Describe the solution you've provided**

At @speedshop we have a client that uses LaunchDarkly. One thing we noticed was that the Ruby SDK relies on the `Thread` very extensively, either directly or through the `concurrent-ruby` gem. As a result of this, a number of threads will be created after the first call to LD:

<img width="2120" alt="Xnapper-2025-03-07-16 06 14" src="https://github.com/user-attachments/assets/428fa90a-da75-4de8-9a13-2215d3b3608b" />

This is all expected, and normally this is fine. In some specific circumstances where a deep dive into e.g. performance of each thread is required, not having a thread name could possibly lead to a longer investigation. For example, [the `gvl-tracing` gem](https://github.com/ivoanjo/gvl-tracing) generates [Perfetto](https://ui.perfetto.dev/) profiling results for each thread, that looks like this:

<img width="1854" alt="Xnapper-2025-03-07-15 25 11" src="https://github.com/user-attachments/assets/f1bd0e94-7a52-419d-8d09-d2ec82c1446f" />

The red arrow points to `Thread 11`, which is not obvious as to who created it, what it's used for, etc. Compare that with the thread name of `"puma srv tp 001 from puma 1"` above, which makes it very clear that it's a worker thread within a Puma instance.

This PR updates the code that creates threads to also assign a name to them. After this PR the result of the Perfetto visualization could look like this:

<img width="1874" alt="Xnapper-2025-03-07-15 26 03" src="https://github.com/user-attachments/assets/a78b9e38-202a-464b-91cb-98b70b770342" />

As you can see, now this is a lot easier to understand who owns this thread. Because of the nature of the thread where we don't know exactly when they are created or GC-ed, I believe it is also important to assign thread names whenever possible, so they will show up with a clear name in a profiling result like above.

**Describe alternatives you've considered**

The thread name itself is quite primitive enough that there is no other alternative here. Other good citizens like [the `debug` gem](https://github.com/ruby/debug/blob/bead0984d241a91235e3d3bacd247f0363d2d530/lib/debug/session.rb#L183), [ActiveRecord](https://github.com/rails/rails/blob/aa2bfad1a137c9add1b35de118b391494e13ca06/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb#L45), [Puma](https://github.com/puma/puma/blob/ca201ef69757f8830b636251b0af7a51270eb68a/lib/puma/thread_pool.rb#L126) all provide thread names, so I believe it is good practice to follow in general.

**Additional context**

The `Concurrent::TimerTask` class from `concurrent-ruby`, used in the `EventProcessor` class:

https://github.com/launchdarkly/ruby-server-sdk/blob/39b1e0e591622348f2d01dd992bf16829c25f29a/lib/ldclient-rb/events.rb#L121
https://github.com/launchdarkly/ruby-server-sdk/blob/39b1e0e591622348f2d01dd992bf16829c25f29a/lib/ldclient-rb/events.rb#L125
https://github.com/launchdarkly/ruby-server-sdk/blob/39b1e0e591622348f2d01dd992bf16829c25f29a/lib/ldclient-rb/events.rb#L133

also creates threads internally. Unfortunately it ignores the `name` option and there is no way for us to set a name at least today, so I left it unchanged for now.
