### PR TITLE
fix: Explicitly require openssl gem

### DIFF
--- a/launchdarkly-server-sdk.gemspec
+++ b/launchdarkly-server-sdk.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.1"
   spec.add_runtime_dependency "ld-eventsource", "2.2.6"
   spec.add_runtime_dependency "observer", "~> 0.1.2"
-  spec.add_runtime_dependency "openssl", "~> 3.1"
+  spec.add_runtime_dependency "openssl", "~> 3.1", ">= 3.1.2"
   spec.add_runtime_dependency "semantic", "~> 1.6"
   spec.add_runtime_dependency "zlib", "~> 3.1" unless RUBY_PLATFORM == "java"
   # Please keep ld-eventsource dependency as an exact version so that bugfixes to


### PR DESCRIPTION
OpenSSL 3.6.0 introduced a change in behavior which prevents the SDK
from initializing. To learn more, refer to [this github ticket][1].

To mitigate this, we explicitly depend on the openssl gem instead of
loading the default version shipped with Ruby.

This SDK still advertises Ruby 3.1+ support, which should require a
minimum threshold of openssl-v3.0+. However, Ruby 3.1 is EOL and the
openssl maintainer only implemented fixes in openssl-v3.1+. Thus, we set
the minimum to openssl-v3.1.

[1]: https://github.com/ruby/openssl/issues/949

fixes #333

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add explicit `openssl` runtime dependency (`~> 3.1`, `>= 3.1.2`) in `launchdarkly-server-sdk.gemspec`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fefbbb815bc1b3004c8260a370cc5340f77ce7d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->