### PR TITLE
chore: Allow OS to assign port for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   build-linux:
     uses: ./.github/workflows/build-gem.yml
     strategy:
+      fail-fast: false
       matrix:
         version: ["3.2", "jruby-9.4"]
     with:


### PR DESCRIPTION
Previously we started looking for testing ports starting at 5000. If the
port was in use, we would incrementally search upwards until we found a
port we could use.

A recent change in the GH Windows image resulted in a permission error
being raised before we could find a port to use:

```
Failure/Error: WEBrick::HTTPServer.new(base_opts)

Errno::EACCES:
Permission denied - bind(2) for 127.0.0.1:50018
```

To address this, we are modifying the tests to set a port of 0, which
will allow the OS to assign an available port for us. This removes the
need for this silly retry logic and hard coded port numbers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch StubHTTPServer to OS-assigned ephemeral ports and set CI matrix fail-fast to false.
> 
> - **Tests**:
>   - Use OS-assigned ephemeral port by setting `Port: 0` in `spec/http_util.rb` and capturing actual port from `server.config[:Port]`.
>   - Remove manual port allocation, retry logic, and `@@next_port`/`self.next_port` helpers; simplify `create_server` signature.
> - **CI**:
>   - Disable matrix fail-fast in `jobs.build-linux.strategy` of `.github/workflows/ci.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1a8f9c6ef21ffbbcd64f2d85b2480afc2b1e77f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->