### PR TITLE
fix: Prevent command injection in FileDataSourceImpl

### DIFF
--- a/lib/ldclient-rb/impl/integrations/file_data_source.rb
+++ b/lib/ldclient-rb/impl/integrations/file_data_source.rb
@@ -102,7 +102,7 @@ module LaunchDarkly
             @last_version += 1
           }
 
-          parsed = parse_content(IO.read(path))
+          parsed = parse_content(File.read(path))
           (parsed[:flags] || {}).each do |key, flag|
             flag[:version] = version
             add_item(all_data, FEATURES, flag)


### PR DESCRIPTION
Tracked Internally: SDK-1675
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace IO.read with File.read in FileDataSourceImpl and add tests ensuring filenames aren’t executed as shell commands.
> 
> - **File reading**:
>   - Replace `IO.read(path)` with `File.read(path)` in `lib/ldclient-rb/impl/integrations/file_data_source.rb` for direct, shell-free file access.
> - **Tests**:
>   - Add spec to verify malicious filenames (with shell metacharacters) are treated as literal paths and do not trigger command execution in `spec/integrations/file_data_source_spec.rb`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b38011cdaa33141ce3985c063b17e0b359cea1c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->