### PR TITLE
chore: Add changelog URI to gemspec metadata

### DIFF
--- a/launchdarkly-server-sdk.gemspec
+++ b/launchdarkly-server-sdk.gemspec
@@ -15,9 +15,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/launchdarkly/ruby-server-sdk"
   spec.license       = "Apache-2.0"
 
-  spec.metadata = {
-    "changelog_uri" => "https://github.com/launchdarkly/ruby-server-sdk/blob/main/CHANGELOG.md",
-  }
+  spec.metadata["bug_tracker_uri"] = "https://github.com/launchdarkly/ruby-server-sdk/issues"
+  spec.metadata["changelog_uri"] = "https://github.com/launchdarkly/ruby-server-sdk/blob/main/CHANGELOG.md"
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/launchdarkly/ruby-server-sdk"
 
   spec.files         = Dir["lib/**/*.rb", "README.md", "LICENSE.txt"]
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Added metadata with changelog URI to gemspec.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds standard metadata links (bug tracker, changelog, homepage, source code) to `launchdarkly-server-sdk.gemspec`.
> 
> - **Packaging**
>   - Update `launchdarkly-server-sdk.gemspec` to include RubyGems metadata:
>     - `metadata["bug_tracker_uri"]`
>     - `metadata["changelog_uri"]`
>     - `metadata["homepage_uri"]` (uses `spec.homepage`)
>     - `metadata["source_code_uri"]`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8f945db96cba395ead12f9d9fa754c7cac03c7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->