### PR TITLE
fix: Bump openssl dep to allow 4.x

### DIFF
--- a/launchdarkly-server-sdk.gemspec
+++ b/launchdarkly-server-sdk.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.1"
   spec.add_runtime_dependency "ld-eventsource", "2.2.6"
   spec.add_runtime_dependency "observer", "~> 0.1.2"
-  spec.add_runtime_dependency "openssl", "~> 3.1", ">= 3.1.2"
+  spec.add_runtime_dependency "openssl", ">= 3.1.2", "< 5.0"
   spec.add_runtime_dependency "semantic", "~> 1.6"
   spec.add_runtime_dependency "zlib", "~> 3.1" unless RUBY_PLATFORM == "java"
   # Please keep ld-eventsource dependency as an exact version so that bugfixes to


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Allows installing with OpenSSL 4.x by widening the `openssl` runtime dependency range.
> 
> - In `launchdarkly-server-sdk.gemspec`, change `openssl` requirement from `~> 3.1, >= 3.1.2` to `>= 3.1.2, < 5.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f4997aec6e212645f001ae272e014086eb905ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->