### PR TITLE
chore: Additional testing of diagnostic events

### DIFF
--- a/spec/impl/data_system/streaming_synchronizer_spec.rb
+++ b/spec/impl/data_system/streaming_synchronizer_spec.rb
@@ -384,18 +384,6 @@ change_set_builder, envid)
             # Call log_connection_result without log_connection_started
             synchronizer.send(:log_connection_result, true)
           end
-
-          it "resets connection attempt time after logging" do
-            diagnostic_accumulator = double("DiagnosticAccumulator")
-            expect(diagnostic_accumulator).to receive(:record_stream_init).once
-
-            synchronizer.set_diagnostic_accumulator(diagnostic_accumulator)
-            synchronizer.send(:log_connection_started)
-            synchronizer.send(:log_connection_result, true)
-
-            # Another log_connection_result should not record (time was reset)
-            synchronizer.send(:log_connection_result, true)
-          end
         end
       end
     end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands test coverage for diagnostic logging around streaming connections in `StreamingDataSource`.
> 
> - New specs assert `record_stream_init` is called on success and failure with correct timestamp and duration
> - Ensures logging happens only once per connection attempt
> - Confirms no logging occurs when no accumulator is set or when result is logged without a start
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 820e4f0d50a0ce814634760b3c86ab00288e7058. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->