### PR TITLE
ci: switch from SLSA provenance to actions/attest with subject-path

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -4,10 +4,6 @@ inputs:
   dry_run:
     description: 'Is this a dry run. If so no package will be published.'
     required: true
-outputs:
-  gem-hash:
-    description: "base64-encoded sha256 hashes of distribution files"
-    value: ${{ steps.gem-hash.outputs.gem-hash }}
 
 runs:
   using: composite
@@ -16,12 +12,6 @@ runs:
       with:
         pattern: 'gems-*'
         merge-multiple: true
-
-    - name: Hash gem for provenance
-      id: gem-hash
-      shell: bash
-      run: |
-        echo "gem-hash=$(sha256sum launchdarkly-server-sdk-*.gem | base64 -w0)" >> "$GITHUB_OUTPUT"
 
     - name: Publish Library
       shell: bash

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -22,9 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["build-ruby-gem", "build-jruby-gem"]
 
-    outputs:
-      gem-hash: ${{ steps.publish.outputs.gem-hash }}
-
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.
       contents: write
@@ -57,15 +54,8 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
 
-      - name: Generate checksums file
-        if: ${{ !inputs.dry_run }}
-        env:
-          HASHES: ${{ steps.publish.outputs.gem-hash }}
-        run: |
-          echo "$HASHES" | base64 -d > checksums.txt
-
       - name: Attest build provenance
         if: ${{ !inputs.dry_run }}
         uses: actions/attest@v4
         with:
-          subject-checksums: checksums.txt
+          subject-path: 'launchdarkly-server-sdk-*.gem'

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -6,10 +6,6 @@ on:
         description: "Is this a dry run. If so no package will be published."
         type: boolean
         required: true
-      publish_release:
-        description: "Whether to publish (un-draft) the release after uploading artifacts."
-        type: boolean
-        default: true
 
 jobs:
   build-ruby-gem:
@@ -73,18 +69,3 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
-
-  publish-release:
-    needs: ['publish']
-    if: ${{ !inputs.dry_run && inputs.publish_release }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >
-          gh release edit "$(gh release list --repo ${{ github.repository }} --limit 1 --json tagName --jq '.[0].tagName')"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         name: "Get rubygems API key"
-        if: ${{ !inputs.dry_run }}
+        if: ${{ format('{0}', inputs.dry_run) == 'false' }}
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           ssm_parameter_pairs: "/production/common/releasing/rubygems/api_key = GEM_HOST_API_KEY"
@@ -50,12 +50,12 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
 
       - uses: ./.github/actions/publish-docs
-        if: ${{ !inputs.dry_run }}
+        if: ${{ format('{0}', inputs.dry_run) == 'false' }}
         with:
           token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Attest build provenance
-        if: ${{ !inputs.dry_run }}
+        if: ${{ format('{0}', inputs.dry_run) == 'false' }}
         uses: actions/attest@v4
         with:
           subject-path: 'launchdarkly-server-sdk-*.gem'

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -6,6 +6,10 @@ on:
         description: "Is this a dry run. If so no package will be published."
         type: boolean
         required: true
+      publish_release:
+        description: "Whether to publish (un-draft) the release after uploading artifacts."
+        type: boolean
+        default: true
 
 jobs:
   build-ruby-gem:
@@ -28,6 +32,7 @@ jobs:
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.
       contents: write
+      attestations: write # Needed for actions/attest.
 
     steps:
       - uses: actions/checkout@v4
@@ -56,15 +61,30 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
 
-  release-provenance:
-    needs: ["publish"]
+      - name: Generate checksums file
+        if: ${{ !inputs.dry_run }}
+        env:
+          HASHES: ${{ steps.publish.outputs.gem-hash }}
+        run: |
+          echo "$HASHES" | base64 -d > checksums.txt
 
+      - name: Attest build provenance
+        if: ${{ !inputs.dry_run }}
+        uses: actions/attest@v4
+        with:
+          subject-checksums: checksums.txt
+
+  publish-release:
+    needs: ['publish']
+    if: ${{ !inputs.dry_run && inputs.publish_release }}
+    runs-on: ubuntu-latest
     permissions:
-      actions: read
-      id-token: write
       contents: write
-
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
-    with:
-      base64-subjects: "${{ needs.publish.outputs.gem-hash }}"
-      upload-assets: ${{ !inputs.dry_run }}
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          gh release edit "$(gh release list --repo ${{ github.repository }} --limit 1 --json tagName --jq '.[0].tagName')"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,8 +46,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,21 +53,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create release tag
-        env:
-          TAG_NAME: ${{ needs.release-package.outputs.upload-tag-name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
-            echo "Tag ${TAG_NAME} already exists, skipping creation."
-          else
-            echo "Creating tag ${TAG_NAME}."
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag "${TAG_NAME}"
-            git push origin "${TAG_NAME}"
-          fi
-
       - uses: ./.github/actions/setup
         with:
           version: "3.2"
@@ -100,19 +85,3 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
-
-  publish-release:
-    needs: ['release-package', 'publish']
-    if: ${{ needs.release-package.outputs.release-created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ needs.release-package.outputs.upload-tag-name }}
-        run: >
-          gh release edit "$TAG_NAME"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,9 +40,6 @@ jobs:
     needs: ["release-package", "build-ruby-gem", "build-jruby-gem"]
     if: ${{ needs.release-package.outputs.release-created == 'true' }}
 
-    outputs:
-      gem-hash: ${{ steps.publish.outputs.gem-hash }}
-
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.
       contents: write # Contents and pull-requests are for release-please to make releases.
@@ -75,13 +72,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate checksums file
-        env:
-          HASHES: ${{ steps.publish.outputs.gem-hash }}
-        run: |
-          echo "$HASHES" | base64 -d > checksums.txt
-
       - name: Attest build provenance
         uses: actions/attest@v4
         with:
-          subject-checksums: checksums.txt
+          subject-path: 'launchdarkly-server-sdk-*.gem'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,9 +46,27 @@ jobs:
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.
       contents: write # Contents and pull-requests are for release-please to make releases.
+      attestations: write # Needed for actions/attest.
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create release tag
+        env:
+          TAG_NAME: ${{ needs.release-package.outputs.upload-tag-name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
 
       - uses: ./.github/actions/setup
         with:
@@ -72,17 +90,29 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  release-provenance:
-    needs: ["release-package", "publish"]
+      - name: Generate checksums file
+        env:
+          HASHES: ${{ steps.publish.outputs.gem-hash }}
+        run: |
+          echo "$HASHES" | base64 -d > checksums.txt
+
+      - name: Attest build provenance
+        uses: actions/attest@v4
+        with:
+          subject-checksums: checksums.txt
+
+  publish-release:
+    needs: ['release-package', 'publish']
     if: ${{ needs.release-package.outputs.release-created == 'true' }}
-
+    runs-on: ubuntu-latest
     permissions:
-      actions: read
-      id-token: write
       contents: write
-
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
-    with:
-      base64-subjects: "${{ needs.publish.outputs.gem-hash }}"
-      upload-assets: true
-      upload-tag-name: ${{ needs.release-package.outputs.upload-tag-name }}
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-package.outputs.upload-tag-name }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,6 @@ jobs:
 
     outputs:
       release-created: ${{ steps.release.outputs.release_created }}
-      upload-tag-name: ${{ steps.release.outputs.tag_name }}
 
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,10 +1,10 @@
-## Verifying SDK build provenance with the SLSA framework
+## Verifying SDK build provenance with GitHub artifact attestations
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
 
-As part of [SLSA requirements for level 3 compliance](https://slsa.dev/spec/v1.0/requirements), LaunchDarkly publishes provenance about our SDK package builds using [GitHub's generic SLSA3 provenance generator](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#generation-of-slsa3-provenance-for-arbitrary-projects) for distribution alongside our packages. These attestations are available for download from the GitHub release page for the release version under Assets > `multiple-provenance.intoto.jsonl`.
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
 
-To verify SLSA provenance attestations, we recommend using [slsa-verifier](https://github.com/slsa-framework/slsa-verifier). Example usage for verifying SDK packages is included below:
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying SDK packages is included below:
 
 <!-- x-release-please-start-version -->
 ```
@@ -17,27 +17,33 @@ SDK_VERSION=8.13.0
 # Download gem
 $ gem fetch launchdarkly-server-sdk -v $SDK_VERSION
 
-# Download provenance from Github release
-$ curl --location -O \
-  https://github.com/launchdarkly/ruby-server-sdk/releases/download/${SDK_VERSION}/launchdarkly-server-sdk-${SDK_VERSION}.gem.intoto.jsonl
-
-# Run slsa-verifier to verify provenance against package artifacts 
-$ slsa-verifier verify-artifact \
---provenance-path launchdarkly-server-sdk-${SDK_VERSION}.gem.intoto.jsonl \
---source-uri github.com/launchdarkly/ruby-server-sdk \
-launchdarkly-server-sdk-${SDK_VERSION}.gem
+# Verify provenance using the GitHub CLI
+$ gh attestation verify launchdarkly-server-sdk-${SDK_VERSION}.gem --owner launchdarkly
 ```
 
 Below is a sample of expected output.
 
 ```
-Verified signature against tlog entry index 78214752 at URL: https://rekor.sigstore.dev/api/v1/log/entries/24296fb24b8ad77ab941c118ef7e0b2d656b962a0d670c6ac91cfa37d07b7b121ae560b00a978ecf
-Verified build using builder "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.7.0" at commit f43b3ad834103fdc282652efbfe4963e8dfa737b
-Verifying artifact launchdarkly-server-sdk-8.3.0.gem: PASSED
+Loaded digest sha256:... for file://launchdarkly-server-sdk-8.13.0.gem
+Loaded 1 attestation from GitHub API
 
-PASSED: Verified SLSA provenance
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/ruby-server-sdk
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/ruby-server-sdk
+  - Signer workflow: .github/workflows/release-please.yml
 ```
 
-Alternatively, to verify the provenance manually, the SLSA framework specifies [recommendations for verifying build artifacts](https://slsa.dev/spec/v1.0/verifying-artifacts) in their documentation.
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
 
-**Note:** These instructions do not apply when building our SDKs from source. 
+**Note:** These instructions do not apply when building our SDKs from source.  

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Contributing
  
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this SDK.
 
-Verifying SDK build provenance with GitHub artifact attestations
+Verifying SDK build provenance with the SLSA framework
 ------------
 
-LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md).
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 About LaunchDarkly
 -----------

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Contributing
  
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this SDK.
 
-Verifying SDK build provenance with the SLSA framework
+Verifying SDK build provenance with GitHub artifact attestations
 ------------
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 About LaunchDarkly
 -----------

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
       "release-type": "ruby",
       "bump-minor-pre-major": true,
       "versioning": "default",
+      "draft": true,
       "include-component-in-tag": false,
       "include-v-in-tag": false,
       "extra-files": ["PROVENANCE.md", "lib/ldclient-rb/version.rb"]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
       "release-type": "ruby",
       "bump-minor-pre-major": true,
       "versioning": "default",
-      "draft": true,
       "force-tag-creation": true,
       "include-component-in-tag": false,
       "include-v-in-tag": false,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,9 +5,13 @@
       "bump-minor-pre-major": true,
       "versioning": "default",
       "draft": true,
+      "force-tag-creation": true,
       "include-component-in-tag": false,
       "include-v-in-tag": false,
-      "extra-files": ["PROVENANCE.md", "lib/ldclient-rb/version.rb"]
+      "extra-files": [
+        "PROVENANCE.md",
+        "lib/ldclient-rb/version.rb"
+      ]
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
       "release-type": "ruby",
       "bump-minor-pre-major": true,
       "versioning": "default",
-      "force-tag-creation": true,
       "include-component-in-tag": false,
       "include-v-in-tag": false,
       "extra-files": [


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

N/A — CI-only and documentation changes, no application code or tests affected.

**Related issues**

Supports the org-wide migration to immutable GitHub releases. Once immutable releases are enabled, artifacts can no longer be uploaded after a release is published. This repo only uses attestation (no binary/artifact uploads to the release), so `actions/attest@v4` — which stores attestations via GitHub's attestation API rather than as release assets — is compatible with immutable releases without needing draft releases.

**Describe the solution you've provided**

Changes across six files:

1. **`release-please-config.json`** — Reformatted `extra-files` array to multi-line (no functional change).

2. **`.github/actions/publish/action.yml`** — Removed the `gem-hash` output and "Hash gem for provenance" step. These existed to produce base64-encoded checksums for the old SLSA generator and are no longer needed since attestation now uses `subject-path` directly.

3. **`.github/workflows/release-please.yml`** — In the `publish` job:
   - Replaced the separate `release-provenance` job (SLSA `generator_generic_slsa3` reusable workflow with `upload-assets: true`) with an inline `actions/attest@v4` step using `subject-path: 'launchdarkly-server-sdk-*.gem'`.
   - Added `attestations: write` permission.
   - Removed `gem-hash` from job outputs.
   - Removed orphaned `upload-tag-name` output (was only consumed by the now-removed `release-provenance` job). The `release-created` output is retained as it is still used by downstream jobs.

4. **`.github/workflows/manual-publish.yml`** — Same attestation migration:
   - Replaced the separate `release-provenance` job with an inline `actions/attest@v4` step using `subject-path` gated on dry_run check.
   - Added `attestations: write` permission.
   - Removed `gem-hash` from job outputs.
   - All `dry_run` conditions updated to use `format('{0}', inputs.dry_run) == 'false'` instead of `!inputs.dry_run` (see note below).

5. **`PROVENANCE.md`** — Rewritten to document the new `gh attestation verify` workflow instead of the old `slsa-verifier` approach. Includes updated verification commands and sample output matching the new GitHub attestation API format.

6. **`README.md`** — Minor whitespace cleanup in the provenance section; the original SLSA framework text is preserved verbatim with a link to `PROVENANCE.md` for GitHub-specific details.

### Why `subject-path` instead of `subject-checksums`?

The previous approach used a base64 encode/decode round-trip inherited from the old SLSA generator: the composite action hashed artifacts and base64-encoded the checksums, then the workflow decoded them into a checksums file for `actions/attest`. Since `actions/attest@v4` supports `subject-path` — which accepts file globs and computes checksums internally — the entire round-trip is eliminated. The glob `launchdarkly-server-sdk-*.gem` matches the built gem files directly on disk.

### Why no draft releases?

The old SLSA generator uploaded `.intoto.jsonl` provenance files as release assets (via `upload-assets: true`), which would fail under immutable releases. The new `actions/attest@v4` stores attestations via GitHub's attestation API instead — it does **not** modify the GitHub release. Since this repo has no other artifact uploads, the release can be published directly by release-please without a draft→publish flow.

### Why `format('{0}', inputs.dry_run)` for dry_run checks?

GitHub Actions passes `workflow_dispatch` boolean inputs as strings (`'true'`/`'false'`), but `workflow_call` passes them as actual booleans. The expression `!inputs.dry_run` silently coerces differently depending on the trigger type. Using `format('{0}', inputs.dry_run) == 'false'` normalizes both cases to a string comparison, ensuring the condition works regardless of how the workflow is invoked.

### Updates since last revision

- Reverted the split release-please pattern (two-pass `skip-github-pull-request` / `skip-github-release` with inline tag creation) that was briefly added. This pattern is only needed for repos that upload artifacts to releases (which require draft releases). Since this repo is attestation-only, the standard single-pass release-please is correct and has been restored.

**Describe alternatives you've considered**

- **`subject-checksums`**: An earlier revision decoded base64 hashes into a checksums file for `actions/attest`. This worked but was unnecessarily complex since the artifact files are already on disk in the same job.
- **Draft release pattern**: An earlier revision used draft releases with a `publish-release` job. Simplified since this repo only uses attestation, not artifact uploads.
- **Split release-please pattern**: A two-pass release-please flow (releases first, then PRs) was briefly applied but reverted — it is only needed for repos with artifact uploads that require draft releases.
- **Keep SLSA generator**: Could keep it as a separate reusable workflow, but `actions/attest@v4` is the org-standard replacement and runs inline without requiring a separate job.
- **`fromJSON(inputs.dry_run)`** for boolean coercion: Undocumented behavior when called on an already-boolean value. `format()` is fully documented for both types.

**Additional context**

**⚠️ Items for reviewer attention:**

- **`dry_run` gating correctness**: The `format('{0}', inputs.dry_run) == 'false'` pattern is used in `manual-publish.yml` for the attestation step, secrets retrieval, and docs publishing. Verify that this evaluates correctly for both `workflow_dispatch` (string) and `workflow_call` (boolean) triggers in your environment.
- **Glob pattern correctness**: The `subject-path: 'launchdarkly-server-sdk-*.gem'` glob must match all gem files produced by the build (both CRuby and JRuby variants). The existing publish action already uses the same `launchdarkly-server-sdk-*.gem` glob for `gem push`, so this should be consistent.
- **No `if` guard on attestation in `release-please.yml`**: The `Attest build provenance` step runs unconditionally within the `publish` job (which is itself gated on `release-created == 'true'`). The manual workflow correctly gates on the dry_run check. Confirm this asymmetry is acceptable.
- **PROVENANCE.md version placeholder**: The `SDK_VERSION=8.13.0` in `PROVENANCE.md` is managed by release-please via `extra-files`. Verify that release-please will update this value on the next release.
- **Trailing whitespace in PROVENANCE.md**: The last line has a trailing double-space that was present before and remains — cosmetic only, but noting for completeness.
- `actions/attest@v4` is referenced by major version tag (not pinned SHA), consistent with existing `actions/checkout@v4` usage in this repo.

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84