### PR TITLE
fix: parse FDv2 goodbye events with only a reason field

### DIFF
--- a/lib/ldclient-rb/impl/data_system/protocolv2.rb
+++ b/lib/ldclient-rb/impl/data_system/protocolv2.rb
@@ -160,21 +160,11 @@ module LaunchDarkly
           # @return [String] The reason for goodbye
           attr_reader :reason
 
-          # @return [Boolean] Whether the goodbye is silent
-          attr_reader :silent
-
-          # @return [Boolean] Whether this represents a catastrophic failure
-          attr_reader :catastrophe
-
           #
           # @param reason [String] The reason for goodbye
-          # @param silent [Boolean] Whether the goodbye is silent
-          # @param catastrophe [Boolean] Whether this represents a catastrophic failure
           #
-          def initialize(reason:, silent:, catastrophe:)
+          def initialize(reason:)
             @reason = reason
-            @silent = silent
-            @catastrophe = catastrophe
           end
 
           #
@@ -185,8 +175,6 @@ module LaunchDarkly
           def to_h
             {
               reason: @reason,
-              silent: @silent,
-              catastrophe: @catastrophe,
             }
           end
 
@@ -199,12 +187,10 @@ module LaunchDarkly
           #
           def self.from_h(data)
             reason = data[:reason]
-            silent = data[:silent]
-            catastrophe = data[:catastrophe]
 
-            raise ArgumentError, "Missing required fields in Goodbye" if reason.nil? || silent.nil? || catastrophe.nil?
+            raise ArgumentError, "Missing required fields in Goodbye" if reason.nil?
 
-            new(reason: reason, silent: silent, catastrophe: catastrophe)
+            new(reason: reason)
           end
         end
 

--- a/lib/ldclient-rb/impl/data_system/streaming.rb
+++ b/lib/ldclient-rb/impl/data_system/streaming.rb
@@ -231,9 +231,7 @@ module LaunchDarkly
 
           when LaunchDarkly::Interfaces::DataSystem::EventName::GOODBYE
             goodbye = LaunchDarkly::Impl::DataSystem::ProtocolV2::Goodbye.from_h(JSON.parse(message.data, symbolize_names: true))
-            unless goodbye.silent
-              @logger.error { "[LDClient] SSE server received error: #{goodbye.reason} (catastrophe: #{goodbye.catastrophe})" }
-            end
+            @logger.info { "[LDClient] SSE server received goodbye: #{goodbye.reason}" }
             nil
 
           when LaunchDarkly::Interfaces::DataSystem::EventName::ERROR

--- a/spec/impl/data_system/streaming_synchronizer_spec.rb
+++ b/spec/impl/data_system/streaming_synchronizer_spec.rb
@@ -224,9 +224,7 @@ module LaunchDarkly
               )
             )
             goodbye = LaunchDarkly::Impl::DataSystem::ProtocolV2::Goodbye.new(
-              reason: "test reason",
-              silent: true,
-              catastrophe: false
+              reason: "test reason"
             )
             selector = LaunchDarkly::Interfaces::DataSystem::Selector.new(state: "p:SOMETHING:300", version: 300)
 


### PR DESCRIPTION
## Summary
- The FDv2 `goodbye` event is specified to carry only a `reason` field. The Ruby SDK's `Goodbye` class incorrectly declared `silent` and `catastrophe`, and `from_h` *raised* `ArgumentError` if either was missing — meaning a spec-compliant payload would fail to parse.
- This PR removes both fields from the class, the constructor, `to_h`, and `from_h`. `from_h` now requires only `reason`.
- Streaming consumer in `lib/ldclient-rb/impl/data_system/streaming.rb` was logging at `@logger.error` and reading `goodbye.silent` / `goodbye.catastrophe`. Replaced with `@logger.info { "[LDClient] SSE server received goodbye: #{goodbye.reason}" }` — a goodbye is a normal protocol signal, matching the Java SDK.

## Test plan
- [x] `bundle exec rspec spec/impl/data_system/streaming_synchronizer_spec.rb` — 14 examples, 0 failures.
- [x] `bundle exec rspec spec/impl/data_system/` — 125 examples, 0 failures.
- [x] `grep -rn` for `goodbye.silent` / `goodbye.catastrophe` — no remaining references.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrows `Goodbye` parsing/serialization to the spec-required `reason` field and adjusts logging; behavior change is limited to handling `GOODBYE` SSE events.
> 
> **Overview**
> Aligns FDv2 `Goodbye` event handling with the protocol by removing the unsupported `silent`/`catastrophe` fields from `ProtocolV2::Goodbye` (constructor, `to_h`, and `from_h` now only require `reason`).
> 
> Updates the streaming SSE consumer to stop treating `GOODBYE` as an error condition and instead log it at `info`, and adjusts the streaming synchronizer spec to construct goodbye events with only `reason`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17ff311749d5e39ba6e5fb8646a78ccfcc1c35fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->