### PR TITLE
feat: Drop persistent-store cache after FDv2 in-memory store init

### DIFF
--- a/lib/ldclient-rb/impl/data_store/feature_store_client_wrapper.rb
+++ b/lib/ldclient-rb/impl/data_store/feature_store_client_wrapper.rb
@@ -65,6 +65,18 @@ module LaunchDarkly
           @store.initialized?
         end
 
+        #
+        # Passthrough for the FDv2 store coordinator. If the wrapped store supports
+        # disabling its cache (e.g. {LaunchDarkly::Integrations::Util::CachingStoreWrapper}),
+        # forward the call; otherwise no-op.
+        #
+        # @return [void]
+        #
+        def disable_cache
+          return unless @store.respond_to?(:disable_cache)
+          wrapper { @store.disable_cache }
+        end
+
         # (see LaunchDarkly::Interfaces::FeatureStore#stop)
         def stop
           poller_to_stop = nil

--- a/lib/ldclient-rb/impl/data_store/store.rb
+++ b/lib/ldclient-rb/impl/data_store/store.rb
@@ -221,6 +221,12 @@ module LaunchDarkly
           # Switch to memory store as active
           @active_store = @memory_store
 
+          # In-memory store is now authoritative. Disable the persistent-store cache
+          # so we don't hold a duplicate copy of every flag. Done before the
+          # persistent_store.init below so the wrapper can skip its cache-population
+          # loop on this very call.
+          disable_persistent_cache
+
           # Persist to persistent store if configured and writable
           @persistent_store.init(collections) if should_persist?
 
@@ -269,6 +275,24 @@ module LaunchDarkly
 
           # Send change events
           send_change_events(affected_items) unless affected_items.empty?
+        end
+
+        #
+        # Disable the persistent store's in-memory cache, if it has one. The FDv2 in-memory
+        # store is now the source of truth, so the cache is dead weight and would just
+        # hold a duplicate copy of every flag.
+        #
+        # @return [void]
+        #
+        private def disable_persistent_cache
+          return if @persistent_store.nil?
+          return unless @persistent_store.respond_to?(:disable_cache)
+
+          begin
+            @persistent_store.disable_cache
+          rescue => e
+            @logger.warn { "[LDClient] Failed to disable persistent store cache: #{e.message}" }
+          end
         end
 
         #

--- a/lib/ldclient-rb/impl/integrations/redis_impl.rb
+++ b/lib/ldclient-rb/impl/integrations/redis_impl.rb
@@ -93,6 +93,10 @@ module LaunchDarkly
           def stop
             @wrapper.stop
           end
+
+          def disable_cache
+            @wrapper.disable_cache
+          end
         end
 
         class RedisStoreImplBase

--- a/lib/ldclient-rb/integrations/consul.rb
+++ b/lib/ldclient-rb/integrations/consul.rb
@@ -32,8 +32,12 @@ module LaunchDarkly
       # @option opts [String] :url   shortcut for setting the `url` property of the Consul client configuration
       # @option opts [String] :prefix  namespace prefix to add to all keys used by LaunchDarkly
       # @option opts [Logger] :logger  a `Logger` instance; defaults to `Config.default_logger`
-      # @option opts [Integer] :expiration (15)  expiration time for the in-memory cache, in seconds; 0 for no local caching
-      # @option opts [Integer] :capacity (1000)  maximum number of items in the cache
+      # @option opts [Integer] :expiration (15)  expiration time for the in-memory cache, in seconds; 0 for no local caching.
+      #   When the SDK is configured to use FDv2, the persistent-store cache is automatically
+      #   dropped once the in-memory store has been initialized, so this setting only affects
+      #   the brief bootstrap window before the first set of flag data has been received.
+      # @option opts [Integer] :capacity (1000)  maximum number of items in the cache.
+      #   Same FDv2 caveat as `:expiration` applies.
       # @return [LaunchDarkly::Interfaces::FeatureStore]  a feature store object
       #
       def self.new_feature_store(opts = {})

--- a/lib/ldclient-rb/integrations/dynamodb.rb
+++ b/lib/ldclient-rb/integrations/dynamodb.rb
@@ -42,8 +42,12 @@ module LaunchDarkly
       # @option opts [Object] :existing_client  an already-constructed DynamoDB client for the feature store to use
       # @option opts [String] :prefix  namespace prefix to add to all keys used by LaunchDarkly
       # @option opts [Logger] :logger  a `Logger` instance; defaults to `Config.default_logger`
-      # @option opts [Integer] :expiration (15)  expiration time for the in-memory cache, in seconds; 0 for no local caching
-      # @option opts [Integer] :capacity (1000)  maximum number of items in the cache
+      # @option opts [Integer] :expiration (15)  expiration time for the in-memory cache, in seconds; 0 for no local caching.
+      #   When the SDK is configured to use FDv2, the persistent-store cache is automatically
+      #   dropped once the in-memory store has been initialized, so this setting only affects
+      #   the brief bootstrap window before the first set of flag data has been received.
+      # @option opts [Integer] :capacity (1000)  maximum number of items in the cache.
+      #   Same FDv2 caveat as `:expiration` applies.
       # @return [LaunchDarkly::Interfaces::FeatureStore]  a feature store object
       #
       def self.new_feature_store(table_name, opts = {})

--- a/lib/ldclient-rb/integrations/redis.rb
+++ b/lib/ldclient-rb/integrations/redis.rb
@@ -50,8 +50,12 @@ module LaunchDarkly
       # @option opts [String] :prefix (default_prefix)  namespace prefix to add to all hash keys used by LaunchDarkly
       # @option opts [Logger] :logger  a `Logger` instance; defaults to `Config.default_logger`
       # @option opts [Integer] :max_connections  size of the Redis connection pool
-      # @option opts [Integer] :expiration (15)  expiration time for the in-memory cache, in seconds; 0 for no local caching
-      # @option opts [Integer] :capacity (1000)  maximum number of items in the cache
+      # @option opts [Integer] :expiration (15)  expiration time for the in-memory cache, in seconds; 0 for no local caching.
+      #   When the SDK is configured to use FDv2, the persistent-store cache is automatically
+      #   dropped once the in-memory store has been initialized, so this setting only affects
+      #   the brief bootstrap window before the first set of flag data has been received.
+      # @option opts [Integer] :capacity (1000)  maximum number of items in the cache.
+      #   Same FDv2 caveat as `:expiration` applies.
       # @option opts [Object] :pool  custom connection pool, if desired
       # @option opts [Boolean] :pool_shutdown_on_close whether calling `close` should shutdown the custom connection pool;
       #   this is true by default, and should be set to false only if you are managing the pool yourself and want its

--- a/lib/ldclient-rb/integrations/util/store_wrapper.rb
+++ b/lib/ldclient-rb/integrations/util/store_wrapper.rb
@@ -61,50 +61,52 @@ module LaunchDarkly
           @core.init_internal(all_data)
           @inited.make_true
 
-          unless @cache.nil?
-            @cache.clear
+          cache = @cache
+          unless cache.nil?
+            cache.clear
             all_data.each do |kind, items|
-              @cache[kind] = items_if_not_deleted(items)
+              cache[kind] = items_if_not_deleted(items)
               items.each do |key, item|
-                @cache[item_cache_key(kind, key)] = [item]
+                cache[item_cache_key(kind, key)] = [item]
               end
             end
           end
         end
 
         def get(kind, key)
-          unless @cache.nil?
-            cache_key = item_cache_key(kind, key)
-            cached = @cache[cache_key] # note, item entries in the cache are wrapped in an array so we can cache nil values
+          cache = @cache
+          cache_key = item_cache_key(kind, key)
+          unless cache.nil?
+            cached = cache[cache_key] # note, item entries in the cache are wrapped in an array so we can cache nil values
             return item_if_not_deleted(cached[0]) unless cached.nil?
           end
 
           item = @core.get_internal(kind, key)
 
-          unless @cache.nil?
-            @cache[cache_key] = [item]
-          end
+          cache[cache_key] = [item] unless cache.nil?
 
           item_if_not_deleted(item)
         end
 
         def all(kind)
-          unless @cache.nil?
-            items = @cache[all_cache_key(kind)]
+          cache = @cache
+          unless cache.nil?
+            items = cache[all_cache_key(kind)]
             return items unless items.nil?
           end
 
           items = items_if_not_deleted(@core.get_all_internal(kind))
-          @cache[all_cache_key(kind)] = items unless @cache.nil?
+          cache[all_cache_key(kind)] = items unless cache.nil?
           items
         end
 
         def upsert(kind, item)
           new_state = @core.upsert_internal(kind, item)
 
-          unless @cache.nil?
-            @cache[item_cache_key(kind, item[:key])] = [new_state]
-            @cache.delete(all_cache_key(kind))
+          cache = @cache
+          unless cache.nil?
+            cache[item_cache_key(kind, item[:key])] = [new_state]
+            cache.delete(all_cache_key(kind))
           end
         end
 
@@ -115,18 +117,36 @@ module LaunchDarkly
         def initialized?
           return true if @inited.value
 
-          if @cache.nil?
+          cache = @cache
+          if cache.nil?
             result = @core.initialized_internal?
           else
-            result = @cache[inited_cache_key]
+            result = cache[inited_cache_key]
             if result.nil?
               result = @core.initialized_internal?
-              @cache[inited_cache_key] = result
+              cache[inited_cache_key] = result
             end
           end
 
           @inited.make_true if result
           result
+        end
+
+        #
+        # Disable the in-memory cache. Releases the cache reference so subsequent operations
+        # bypass it and go directly to the underlying core. Safe to call multiple times.
+        #
+        # Called by the FDv2 store coordinator once the in-memory store has become the
+        # source of truth and the persistent-store cache is no longer useful. Internal --
+        # not part of the public API.
+        #
+        # @return [void]
+        #
+        def disable_cache
+          cache = @cache
+          return if cache.nil?
+          @cache = nil
+          cache.clear
         end
 
         def stop

--- a/spec/impl/data_store/feature_store_client_wrapper_spec.rb
+++ b/spec/impl/data_store/feature_store_client_wrapper_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ldclient-rb/impl/data_store/feature_store_client_wrapper"
+
+module LaunchDarkly
+  module Impl
+    module DataStore
+      describe FeatureStoreClientWrapperV2 do
+        let(:logger) { double.as_null_object }
+        let(:status_sink) { double(update_status: nil) }
+
+        describe "#disable_cache" do
+          it "forwards to the underlying store when supported" do
+            inner = double("store", disable_cache: nil, init: nil, get: nil, all: nil, delete: nil, upsert: nil, initialized?: false, stop: nil)
+            expect(inner).to receive(:disable_cache).once
+
+            wrapper = described_class.new(inner, status_sink, logger)
+            wrapper.disable_cache
+          end
+
+          it "is a no-op when the underlying store does not respond to disable_cache" do
+            inner = Class.new do
+              def init(_); end
+              def get(_, _); end
+              def all(_); end
+              def delete(_, _, _); end
+              def upsert(_, _); end
+              def initialized?; false; end
+              def stop; end
+            end.new
+
+            wrapper = described_class.new(inner, status_sink, logger)
+            expect { wrapper.disable_cache }.not_to raise_error
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/impl/data_store/store_spec.rb
+++ b/spec/impl/data_store/store_spec.rb
@@ -41,7 +41,7 @@ module LaunchDarkly
         class StubPersistentStore
           include LaunchDarkly::Interfaces::FeatureStore
 
-          attr_reader :init_called_count, :upsert_calls, :data, :init_errors
+          attr_reader :init_called_count, :upsert_calls, :data, :init_errors, :disable_cache_called_count
 
           def initialize(should_fail: false)
             @data = {
@@ -53,6 +53,11 @@ module LaunchDarkly
             @upsert_calls = []
             @should_fail = should_fail
             @init_errors = []
+            @disable_cache_called_count = 0
+          end
+
+          def disable_cache
+            @disable_cache_called_count += 1
           end
 
           def init(all_data)
@@ -100,6 +105,39 @@ module LaunchDarkly
             @init_called_count = 0
             @upsert_calls = []
             @init_errors = []
+            @disable_cache_called_count = 0
+          end
+        end
+
+        # Stub feature store that does NOT respond to disable_cache (custom user store).
+        class NonDisablingPersistentStore
+          include LaunchDarkly::Interfaces::FeatureStore
+
+          attr_reader :init_called_count
+
+          def initialize
+            @init_called_count = 0
+            @data = {}
+          end
+
+          def init(all_data)
+            @init_called_count += 1
+            @data = all_data
+          end
+
+          def get(_kind, _key); nil; end
+          def all(kind); @data[kind] || {}; end
+          def upsert(_kind, _item); end
+          def delete(_kind, _key, _version); end
+          def initialized?; @init_called_count > 0; end
+          def stop; end
+        end
+
+        # Stub feature store whose disable_cache raises -- to verify Store keeps operating.
+        class RaisingPersistentStore < StubPersistentStore
+          def disable_cache
+            super
+            raise RuntimeError, "boom"
           end
         end
 
@@ -576,6 +614,82 @@ module LaunchDarkly
 
               expect(persistent_store.upsert_calls).to be_empty
             end
+          end
+        end
+
+        describe "FDv2 cache lifecycle" do
+          let(:flag_change) do
+            LaunchDarkly::Interfaces::DataSystem::Change.new(
+              action: LaunchDarkly::Interfaces::DataSystem::ChangeType::PUT,
+              kind: LaunchDarkly::Interfaces::DataSystem::ObjectKind::FLAG,
+              key: flag_key,
+              version: 1,
+              object: flag_data
+            )
+          end
+
+          let(:full_change_set) do
+            LaunchDarkly::Interfaces::DataSystem::ChangeSet.new(
+              intent_code: LaunchDarkly::Interfaces::DataSystem::IntentCode::TRANSFER_FULL,
+              changes: [flag_change],
+              selector: LaunchDarkly::Interfaces::DataSystem::Selector.no_selector
+            )
+          end
+
+          it "disables the persistent store cache when the memory store receives its first full payload" do
+            persistent = StubPersistentStore.new
+            subject.with_persistence(persistent, true, nil)
+
+            subject.apply(full_change_set, true)
+
+            expect(persistent.disable_cache_called_count).to eq(1)
+          end
+
+          it "disables the cache even when persist is false (read-only persistent store)" do
+            persistent = StubPersistentStore.new
+            subject.with_persistence(persistent, false, nil)
+
+            subject.apply(full_change_set, false)
+
+            expect(persistent.disable_cache_called_count).to eq(1)
+          end
+
+          it "tolerates a persistent store that does not respond to disable_cache" do
+            persistent = NonDisablingPersistentStore.new
+            subject.with_persistence(persistent, true, nil)
+
+            expect { subject.apply(full_change_set, true) }.not_to raise_error
+            expect(persistent.init_called_count).to eq(1)
+          end
+
+          it "logs a warning if disable_cache raises but continues operating" do
+            persistent = RaisingPersistentStore.new
+            subject.with_persistence(persistent, true, nil)
+            expect(logger).to receive(:warn)
+
+            expect { subject.apply(full_change_set, true) }.not_to raise_error
+            expect(persistent.init_called_count).to eq(1)
+            expect(persistent.disable_cache_called_count).to eq(1)
+          end
+
+          it "keeps Store#commit working after the cache is disabled" do
+            persistent = StubPersistentStore.new
+            subject.with_persistence(persistent, true, nil)
+            subject.apply(full_change_set, true)
+
+            persistent.reset_tracking
+            expect(subject.commit).to be_nil
+            expect(persistent.init_called_count).to eq(1)
+          end
+
+          it "is called on every full transfer (idempotent under repeated set_basis)" do
+            persistent = StubPersistentStore.new
+            subject.with_persistence(persistent, true, nil)
+
+            subject.apply(full_change_set, true)
+            subject.apply(full_change_set, true)
+
+            expect(persistent.disable_cache_called_count).to eq(2)
           end
         end
       end

--- a/spec/integrations/util/store_wrapper_spec.rb
+++ b/spec/integrations/util/store_wrapper_spec.rb
@@ -247,6 +247,68 @@ module LaunchDarkly
         end
       end
 
+      describe "#disable_cache" do
+        it "releases the cache so subsequent reads bypass it" do
+          core = MockCore.new
+          wrapper = subject.new(core, { expiration: 30 })
+          item = { key: "flag", version: 1 }
+          core.force_set(THINGS, item)
+
+          # prime the cache
+          expect(wrapper.get(THINGS, "flag")).to eq item
+
+          # change underlying value; cached value should still be returned
+          itemv2 = { key: "flag", version: 2 }
+          core.force_set(THINGS, itemv2)
+          expect(wrapper.get(THINGS, "flag")).to eq item
+
+          wrapper.disable_cache
+
+          # after disable, reads see the underlying value
+          expect(wrapper.get(THINGS, "flag")).to eq itemv2
+        end
+
+        it "is a safe no-op when caching is disabled at config time" do
+          wrapper = subject.new(MockCore.new, { expiration: 0 })
+          expect { wrapper.disable_cache }.not_to raise_error
+        end
+
+        it "is idempotent" do
+          wrapper = subject.new(MockCore.new, { expiration: 30 })
+          wrapper.disable_cache
+          expect { wrapper.disable_cache }.not_to raise_error
+        end
+
+        it "does not repopulate the cache on upsert after disable" do
+          core = MockCore.new
+          wrapper = subject.new(core, { expiration: 30 })
+          wrapper.init({ THINGS => {} })
+          wrapper.disable_cache
+
+          item = { key: "flag", version: 1 }
+          wrapper.upsert(THINGS, item)
+
+          # mutate underlying value; if a read came from cache it would still see the upserted item
+          itemv2 = { key: "flag", version: 2 }
+          core.force_set(THINGS, itemv2)
+          expect(wrapper.get(THINGS, "flag")).to eq itemv2
+        end
+
+        it "does not repopulate the cache on get after disable" do
+          core = MockCore.new
+          wrapper = subject.new(core, { expiration: 30 })
+          wrapper.disable_cache
+
+          item = { key: "flag", version: 1 }
+          core.force_set(THINGS, item)
+          expect(wrapper.get(THINGS, "flag")).to eq item
+
+          itemv2 = { key: "flag", version: 2 }
+          core.force_set(THINGS, itemv2)
+          expect(wrapper.get(THINGS, "flag")).to eq itemv2
+        end
+      end
+
       class MockCore
         def initialize
           @data = {}


### PR DESCRIPTION
## Summary

With FDv2, the in-memory store (`InMemoryFeatureStoreV2`) becomes the source of truth for flag evaluations once it receives its first full payload. The persistent store's `CachingStoreWrapper` continues to hold a duplicate copy of every flag and segment in its `ExpiringCache`, even though that cache is never read again post-init -- roughly doubling the in-memory flag footprint when a persistent store is configured.

This change adds a `disable_cache` hook that propagates from `Store#set_basis` through `FeatureStoreClientWrapperV2` (and the `RedisFeatureStore` facade) down to `CachingStoreWrapper`, where it releases the `ExpiringCache` reference. The cache is still populated and useful during the bootstrap window before `set_basis` fires, so `:expiration` / `:capacity` options remain functional during that window; YARD docs on the Redis, DynamoDB, and Consul integrations note the new FDv2 behavior.

While here, this also closes a latent TOCTOU window in `CachingStoreWrapper`'s read paths by capturing `@cache` to a local variable before the existing nil-guards, so a concurrent `disable_cache` cannot NPE an in-flight reader.

Mirrors the Python implementation from `python-server-sdk` PR #426.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache lifecycle behavior for persistent stores by disabling their local cache after the first full FDv2 payload; mistakes could impact persistent-store performance or initialization sequencing. Includes concurrency-sensitive cache handling and new warning-path logging that should be validated under load.
> 
> **Overview**
> With FDv2, the SDK now **drops the persistent-store in-memory cache** once the in-memory store becomes authoritative (after a full `TRANSFER_FULL` payload), reducing duplicate flag/segment memory usage.
> 
> This introduces a `disable_cache` hook that propagates through `Store#set_basis` (best-effort with warning on failure), `FeatureStoreClientWrapperV2`, and the Redis feature-store facade down to `Integrations::Util::CachingStoreWrapper`, which releases/clears its cache and updates read paths to safely capture `@cache` locally to avoid races.
> 
> Updates YARD docs for Redis/DynamoDB/Consul cache options to note the FDv2 bootstrap-only behavior, and adds specs covering forwarding/no-op behavior, idempotency, race-safe bypass after disable, and tolerance of missing/raising `disable_cache` implementations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1db3fab703621420ebb59f474f872ce35584b5c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->