### PR TITLE
chore: remove FDv2 pre-release warnings for GA promotion

### DIFF
--- a/lib/ldclient-rb/config.rb
+++ b/lib/ldclient-rb/config.rb
@@ -697,9 +697,6 @@ module LaunchDarkly
   #
   # Configuration for LaunchDarkly's data acquisition strategy.
   #
-  # This is not stable and is not subject to any backwards compatibility guarantees
-  # or semantic versioning. It is not suitable for production usage.
-  #
   class DataSystemConfig
     #
     # @param initializers [Array<#build(String, Config)>, nil] The (optional) array of builders

--- a/lib/ldclient-rb/impl/data_system/protocolv2.rb
+++ b/lib/ldclient-rb/impl/data_system/protocolv2.rb
@@ -12,9 +12,6 @@ module LaunchDarkly
         #
         # DeleteObject specifies the deletion of a particular object.
         #
-        # This type is not stable, and not subject to any backwards
-        # compatibility guarantees or semantic versioning. It is not suitable for production usage.
-        #
         class DeleteObject
           # @return [Integer] The version
           attr_reader :version
@@ -78,9 +75,6 @@ module LaunchDarkly
 
         #
         # PutObject specifies the addition of a particular object with upsert semantics.
-        #
-        # This type is not stable, and not subject to any backwards
-        # compatibility guarantees or semantic versioning. It is not suitable for production usage.
         #
         class PutObject
           # @return [Integer] The version
@@ -153,9 +147,6 @@ module LaunchDarkly
         #
         # Goodbye represents a goodbye event.
         #
-        # This type is not stable, and not subject to any backwards
-        # compatibility guarantees or semantic versioning. It is not suitable for production usage.
-        #
         class Goodbye
           # @return [String] The reason for goodbye
           attr_reader :reason
@@ -196,9 +187,6 @@ module LaunchDarkly
 
         #
         # Error represents an error event.
-        #
-        # This type is not stable, and not subject to any backwards
-        # compatibility guarantees or semantic versioning. It is not suitable for production usage.
         #
         class Error
           # @return [String] The payload ID

--- a/lib/ldclient-rb/integrations/file_data.rb
+++ b/lib/ldclient-rb/integrations/file_data.rb
@@ -108,9 +108,6 @@ module LaunchDarkly
       #
       # Returns a builder for the FDv2-compatible file data source.
       #
-      # This method is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-      #
       # This method returns a builder proc that can be used with the FDv2 data system
       # configuration as both an Initializer and a Synchronizer. When used as an Initializer
       # (via `fetch`), it reads files once. When used as a Synchronizer (via `sync`), it

--- a/lib/ldclient-rb/integrations/test_data_v2.rb
+++ b/lib/ldclient-rb/integrations/test_data_v2.rb
@@ -9,9 +9,6 @@ module LaunchDarkly
     # A mechanism for providing dynamically updatable feature flag state in a
     # simplified form to an SDK client in test scenarios using the FDv2 protocol.
     #
-    # This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-    # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-    #
     # Unlike {LaunchDarkly::Integrations::FileData}, this mechanism does not use any external resources. It
     # provides only the data that the application has put into it using the {#update} method.
     #

--- a/lib/ldclient-rb/interfaces/data_system.rb
+++ b/lib/ldclient-rb/interfaces/data_system.rb
@@ -6,9 +6,6 @@ module LaunchDarkly
       #
       # EventName represents the name of an event that can be sent by the server for FDv2.
       #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-      #
       module EventName
         # Specifies that an object should be added to the data set with upsert semantics.
         PUT_OBJECT = :"put-object"
@@ -35,9 +32,6 @@ module LaunchDarkly
       #
       # ObjectKind represents the kind of object.
       #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-      #
       module ObjectKind
         # Represents a feature flag.
         FLAG = "flag"
@@ -49,9 +43,6 @@ module LaunchDarkly
       #
       # ChangeType specifies if an object is being upserted or deleted.
       #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-      #
       module ChangeType
         # Represents an object being upserted.
         PUT = "put"
@@ -62,9 +53,6 @@ module LaunchDarkly
 
       #
       # IntentCode represents the various intents that can be sent by the server.
-      #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
       #
       module IntentCode
         # The server intends to send a full data set.
@@ -80,9 +68,6 @@ module LaunchDarkly
       #
       # DataStoreMode represents the mode of operation of a Data Store in FDV2 mode.
       #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-      #
       module DataStoreMode
         # Indicates that the data store is read-only. Data will never be written back to the store by the SDK.
         READ_ONLY = :read_only
@@ -94,9 +79,6 @@ module LaunchDarkly
 
       #
       # Selector represents a particular snapshot of data.
-      #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
       #
       class Selector
         # @return [String] The state
@@ -196,9 +178,6 @@ module LaunchDarkly
       #
       # Change represents a change to a piece of data, such as an update or deletion.
       #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-      #
       class Change
         # @return [String] The action ({ChangeType})
         attr_reader :action
@@ -234,9 +213,6 @@ module LaunchDarkly
       #
       # ChangeSet represents a list of changes to be applied.
       #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-      #
       class ChangeSet
         # @return [String] The intent code ({IntentCode})
         attr_reader :intent_code
@@ -262,9 +238,6 @@ module LaunchDarkly
       #
       # Basis represents the initial payload of data that a data source can provide.
       #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-      #
       class Basis
         # @return [ChangeSet] The change set
         attr_reader :change_set
@@ -289,9 +262,6 @@ module LaunchDarkly
 
       #
       # Payload represents a payload delivered in a streaming response.
-      #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
       #
       class Payload
         # @return [String] The payload ID
@@ -357,9 +327,6 @@ module LaunchDarkly
       #
       # ServerIntent represents the type of change associated with the payload.
       #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-      #
       class ServerIntent
         # @return [Payload] The payload
         attr_reader :payload
@@ -404,9 +371,6 @@ module LaunchDarkly
 
       #
       # ChangeSetBuilder is a helper for constructing a ChangeSet.
-      #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
       #
       class ChangeSetBuilder
         # @return [String, nil] The current intent ({IntentCode})
@@ -546,9 +510,6 @@ module LaunchDarkly
       #
       # Update represents the results of a synchronizer's ongoing sync method.
       #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-      #
       class Update
         # @return [Symbol] The data source state ({LaunchDarkly::Interfaces::DataSource::Status})
         attr_reader :state
@@ -592,9 +553,6 @@ module LaunchDarkly
       # Surfacing this signal alongside the {LaunchDarkly::Result} ensures
       # callers cannot silently drop it.
       #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-      #
       class FetchResult
         # @return [LaunchDarkly::Result] A Result containing either a {Basis} or an error.
         attr_reader :result
@@ -635,9 +593,6 @@ module LaunchDarkly
       #
       # SelectorStore represents a component capable of providing Selectors for data retrieval.
       #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-      #
       module SelectorStore
         #
         # Returns a Selector object that defines the criteria for data retrieval.
@@ -651,9 +606,6 @@ module LaunchDarkly
 
       #
       # ReadOnlyStore represents a read-only store interface for retrieving data.
-      #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
       #
       module ReadOnlyStore
         #
@@ -690,9 +642,6 @@ module LaunchDarkly
       #
       # Initializer represents a component capable of retrieving a single data result.
       #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-      #
       module Initializer
         #
         # Returns the name of the initializer.
@@ -722,9 +671,6 @@ module LaunchDarkly
 
       #
       # Synchronizer represents a component capable of synchronizing data from an external source.
-      #
-      # This type is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-      # It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
       #
       module Synchronizer
         #


### PR DESCRIPTION
## Summary

- FDv2 / data-saving mode is going GA per the [SDK Release Standards spec](https://github.com/launchdarkly/sdk-specs/tree/main/specs/RELEASE-sdk-release-standards). GA-stage features must not carry experimental / pre-release warning prose in their public API surface.
- Removes the pre-release warning prose ("not stable, and not subject to any backwards compatibility guarantees", "not suitable for production usage", "in early access. ...join the EAP") from YARD comments on FDv2-related types in `lib/ldclient-rb/interfaces/data_system.rb`, `lib/ldclient-rb/impl/data_system/protocolv2.rb`, `lib/ldclient-rb/integrations/file_data.rb`, `lib/ldclient-rb/integrations/test_data_v2.rb`, and `lib/ldclient-rb/config.rb`. Descriptive YARD comments are preserved.

Tracking: [SDK-2349](https://launchdarkly.atlassian.net/browse/SDK-2349)

## Test plan

- [x] `ruby -c` clean on each changed file
- [ ] CI green

[SDK-2349]: https://launchdarkly.atlassian.net/browse/SDK-2349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation/YARD comments and do not alter runtime behavior or protocol logic.
> 
> **Overview**
> Promotes FDv2/data-saving mode to GA by removing *experimental/early-access* warning prose from the public API documentation.
> 
> Updates YARD comments across `Config::DataSystemConfig`, FDv2 protocol types (`ProtocolV2`), FDv2 integrations (`FileData#data_source_v2`, `TestDataV2`), and `Interfaces::DataSystem` constants/types, while preserving the remaining descriptive docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e25e9d76b6f4dd94a05d6bce9dcca94cf99b1457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->