### PR TITLE
chore: Add Renovate config and pin GitHub Action versions to full semver

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,5 @@
 {
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
-  "packageRules": [
-    {
-      "enabled": false,
-      "matchDatasources": ["npm"],
-      "matchPackageNames": ["*"]
-    }
-  ],
   "vulnerabilityAlerts": {
     "enabled": true
   },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,14 @@
+{
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["*"]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true
+}

--- a/.github/workflows/build-gem.yml
+++ b/.github/workflows/build-gem.yml
@@ -23,7 +23,7 @@ jobs:
       FLAKY: ${{ startsWith(inputs.version, 'jruby') && 'true' || 'false' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
 
       - uses: launchdarkly/gh-actions/actions/persistent-stores@persistent-stores-v0
         with:
@@ -43,7 +43,7 @@ jobs:
       - name: Build gemspec
         run: gem build launchdarkly-server-sdk.gemspec --platform=$BUILD_PLATFORM
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.6.2
         if: ${{ inputs.upload-artifact }}
         with:
           name: gems-${{ inputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
 
       - uses: ./.github/actions/setup
         with:
@@ -42,7 +42,7 @@ jobs:
         shell: powershell
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/manual-publish-docs.yml
+++ b/.github/workflows/manual-publish-docs.yml
@@ -10,7 +10,7 @@ jobs:
       contents: write # Needed in this case to write github pages.
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -28,7 +28,7 @@ jobs:
       attestations: write # Needed for actions/attest.
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
 
       - uses: ./.github/actions/setup
         with:
@@ -56,6 +56,6 @@ jobs:
 
       - name: Attest build provenance
         if: ${{ format('{0}', inputs.dry_run) == 'false' }}
-        uses: actions/attest@v4
+        uses: actions/attest@v4.1.0
         with:
           subject-path: 'launchdarkly-server-sdk-*.gem'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,7 +45,7 @@ jobs:
       attestations: write # Needed for actions/attest.
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
 
       - uses: ./.github/actions/setup
         with:
@@ -70,6 +70,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Attest build provenance
-        uses: actions/attest@v4
+        uses: actions/attest@v4.1.0
         with:
           subject-path: 'launchdarkly-server-sdk-*.gem'


### PR DESCRIPTION
## Summary
- Adds `.github/renovate.json` to enable Renovate with `pinGitHubActionDigests` (matching the pattern used in `js-core` and `learn-release-please`)
- Pins all `@v4` GitHub Action references to their latest full semver patch versions so Renovate can track them with SHA pinning and version comments:
  - `actions/checkout@v4` → `v4.3.1`
  - `actions/upload-artifact@v4` → `v4.6.2`
  - `actions/attest@v4` → `v4.1.0`
- `googleapis/release-please-action` was already SHA-pinned with a version comment — no change needed

Once the terraform PR (adding this repo to the Renovate app installation) merges and applies, Renovate will open a PR replacing these full semver tags with SHA digests plus version comments.

## Test plan
- [ ] Confirm `renovate.json` is valid JSON and matches the expected shape
- [ ] Confirm no bare `@v4` (without patch version) references remain in workflow files
- [ ] After terraform PR merges, verify Renovate opens a PR converting the semver pins to SHA digests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CI configuration and third-party action version pins change; no application runtime, auth, or data-path code is touched.
> 
> **Overview**
> Introduces **Renovate** via `.github/renovate.json` (recommended preset, `pinGitHubActionDigests`, and OSV/vulnerability alerts) so dependency and GitHub Action updates can be automated like other LaunchDarkly repos.
> 
> Across CI, build, publish, and release workflows, **floating `@v4` tags** for `actions/checkout`, `actions/upload-artifact`, and `actions/attest` are replaced with **explicit patch versions** (`v4.3.1`, `v4.6.2`, `v4.1.0`) as a stepping stone before Renovate can pin them to commit SHAs with version comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f81258166e16b4ccb8ce8a009af1d6e0241973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->