### PR TITLE
chore: Fix segment key in FileData example (includes → included)

### DIFF
--- a/lib/ldclient-rb/integrations/file_data.rb
+++ b/lib/ldclient-rb/integrations/file_data.rb
@@ -50,7 +50,7 @@ module LaunchDarkly
     #       "segments": {
     #         "segment-key-1": {
     #           "key": "segment-key-1",
-    #           "includes": [ "user-key-1" ]
+    #           "included": [ "user-key-1" ]
     #         }
     #       }
     #     }


### PR DESCRIPTION
## What

Fixes a functional error in the `FileData` docstring example. The `segments` object uses `"includes"` for the list of context keys:

```json
"segments": {
  "segment-key-1": {
    "key": "segment-key-1",
    "includes": [ "user-key-1" ]
  }
}
```

## Why

The segment model (`LaunchDarkly::Impl::Model::Segment`) deserializes `included` / `excluded`, never `includes`:

```ruby
@included = data[:included] || []
@excluded = data[:excluded] || []
```

An unknown `"includes"` key is silently dropped and `included` defaults to an empty array, so a context listed under `includes` is **never actually added to the segment**. The example doesn't work as written.

## Change

`"includes"` → `"included"` in the `FileData` docstring (`lib/ldclient-rb/integrations/file_data.rb`). Docstring-only; no code behavior change.

## Note

The same example is shared across LaunchDarkly's SDK docs; a companion fix to the canonical snippet source is in launchdarkly/sdk-meta#541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in a comment example; no production code paths are modified.
> 
> **Overview**
> Corrects the **FileData** integration docstring JSON example so segment membership uses `"included"` instead of `"includes"`.
> 
> That matches how `LaunchDarkly::Impl::Model::Segment` reads segment data (`data[:included]`); copying the old example would leave `included` empty and segment targeting would not work as documented. **Docstring-only**—no runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf1ab30658f48e3b5393fdf417a8eefa88043932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->