### PR TITLE
test: Pass private attribute raw paths to LDContext in contract tests

### DIFF
--- a/contract-tests/client_entity.rb
+++ b/contract-tests/client_entity.rb
@@ -291,10 +291,14 @@ class ClientEntity
     if params[:privateAttributes]
       context[:_meta] = {
         privateAttributes: params[:privateAttributes].map do |attribute|
+          # LDContext.create re-parses each _meta private attribute as a
+          # reference string, so hand it the raw path rather than a Reference
+          # object. For a literal name this is the escaped single-component
+          # form (e.g. "/address/street" -> "/~1address~1street").
           if attribute[:literal]
-            LaunchDarkly::Reference.create_literal(attribute[:value])
+            LaunchDarkly::Reference.create_literal(attribute[:value]).raw_path
           else
-            LaunchDarkly::Reference.create(attribute[:value])
+            LaunchDarkly::Reference.create(attribute[:value]).raw_path
           end
         end,
       }


### PR DESCRIPTION
## Summary

The `contextComparison` handler in the contract test service built `LaunchDarkly::Reference` objects and placed them in `_meta.privateAttributes`. But `LDContext.create` re-parses each element of that array as a reference *string* via `Reference.create`, which rejects any non-String/Symbol input. Every private attribute was therefore silently dropped, and context comparisons involving private attributes were never exercised -- both contexts were always compared with empty private-attribute sets.

The SDK's own `LDContext` equality is correct (order-independent set of references; literal names compare equal to the equivalent reference). The defect was isolated to the contract test service.

This passes the reference `raw_path` (a string) to `LDContext.create` instead of the `Reference` object. For a literal attribute name this is the escaped single-component form (e.g. `/address/street` -> `/~1address~1street`), which `LDContext.create` re-parses into the correct reference.

Verified locally by running the `context type/compare` suite from a local sdk-test-harness build against this service: all 16 comparison tests pass, including two negative cases where private attributes are the sole differentiator.

## Note on ordering

The failing behavior was previously masked by a bug in the released test harness (a malformed `privateAttributes` JSON tag) that meant private attributes were never sent for the `contextComparison` command. That harness bug is fixed in launchdarkly/sdk-test-harness#391 (v2) and #392 (v3), which also add the negative tests that catch this. Until the harness fix is released, this SDK's contract-test CI (which downloads the released v2 harness) will not yet exercise the new cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in the contract test service; no production SDK behavior is modified.
> 
> **Overview**
> Fixes **contract test** `contextComparison` so `_meta.privateAttributes` is built the way `LDContext.create` expects.
> 
> The harness was putting `LaunchDarkly::Reference` instances into `privateAttributes`, but `LDContext.create` treats each entry as a **reference string** and re-parses it. Non-string values were dropped, so comparisons never exercised private attributes. The builder now passes each reference’s **`raw_path`** (including escaped literal paths from `Reference.create_literal`) so contexts are created with the intended private-attribute set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e109beb5e2231f9e4d7f9a70db831b84bb05f5ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->