### PR TITLE
feat: Add environment ID support for hooks

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -51,4 +51,4 @@ runs:
         test_service_port: 9000
         enable_persistence_tests: true
         token: ${{ inputs.token }}
-        version: v3.0.0-alpha.6
+        version: v3

--- a/contract-tests/hook.rb
+++ b/contract-tests/hook.rb
@@ -34,6 +34,7 @@ class Hook
         context: @context_filter.filter(evaluation_series_context.context),
         defaultValue: evaluation_series_context.default_value,
         method: evaluation_series_context.method,
+        environmentId: evaluation_series_context.environment_id,
       },
       evaluationSeriesData: data,
       stage: 'beforeEvaluation',
@@ -58,6 +59,7 @@ class Hook
         context: @context_filter.filter(evaluation_series_context.context),
         defaultValue: evaluation_series_context.default_value,
         method: evaluation_series_context.method,
+        environmentId: evaluation_series_context.environment_id,
       },
       evaluationSeriesData: data,
       evaluationDetail: {

--- a/contract-tests/service.rb
+++ b/contract-tests/service.rb
@@ -46,6 +46,7 @@ get '/' do
       'instance-id',
       'anonymous-redaction',
       'evaluation-hooks',
+      'hook-environment-id',
       'omit-anonymous-contexts',
       'client-prereq-events',
       'persistent-data-store-consul',

--- a/lib/ldclient-rb/impl/data_source.rb
+++ b/lib/ldclient-rb/impl/data_source.rb
@@ -7,6 +7,27 @@ require "set"
 module LaunchDarkly
   module Impl
     module DataSource
+      LD_ENVID_HEADER = "X-LD-EnvID"
+
+      #
+      # Records the environment ID reported by LaunchDarkly, when the response headers provide one and the sink is
+      # able to hold it. Externally implemented sinks are not required to support this.
+      #
+      # @param sink [LaunchDarkly::Interfaces::DataSource::UpdateSink, nil]
+      # @param headers [#[], nil]
+      # @return [void]
+      #
+      def self.record_environment_id(sink, headers)
+        return if headers.nil? || !sink.respond_to?(:set_environment_id)
+
+        environment_id = headers[LD_ENVID_HEADER]
+        # The http gem returns arrays for repeated headers; normalize to a string.
+        environment_id = environment_id.first if environment_id.is_a?(Array)
+        return unless environment_id.is_a?(String) && !environment_id.empty?
+
+        sink.set_environment_id(environment_id)
+      end
+
       class StatusProvider
         include LaunchDarkly::Interfaces::DataSource::StatusProvider
 
@@ -41,10 +62,26 @@ module LaunchDarkly
           @dependency_tracker = LaunchDarkly::Impl::DependencyTracker.new
 
           @mutex = Mutex.new
+          @environment_id = nil
           @current_status = LaunchDarkly::Interfaces::DataSource::Status.new(
             LaunchDarkly::Interfaces::DataSource::Status::INITIALIZING,
             Time.now,
             nil)
+        end
+
+        #
+        # @return [String, nil] The environment ID reported by LaunchDarkly, if known
+        #
+        def environment_id
+          @mutex.synchronize { @environment_id }
+        end
+
+        #
+        # @param environment_id [String]
+        # @return [void]
+        #
+        def set_environment_id(environment_id)
+          @mutex.synchronize { @environment_id = environment_id }
         end
 
         def init(all_data)

--- a/lib/ldclient-rb/impl/data_source/polling.rb
+++ b/lib/ldclient-rb/impl/data_source/polling.rb
@@ -1,3 +1,4 @@
+require "ldclient-rb/impl/data_source"
 require "ldclient-rb/impl/repeating_task"
 require "ldclient-rb/impl/util"
 
@@ -35,7 +36,8 @@ module LaunchDarkly
 
         def poll
           begin
-            all_data = @requestor.request_all_data
+            all_data, headers = request_all_data
+            DataSource.record_environment_id(@config.data_source_update_sink, headers)
             if all_data
               update_sink_or_data_store.init(all_data)
               if @initialized.make_true
@@ -90,6 +92,17 @@ module LaunchDarkly
         #
         private def update_sink_or_data_store
           @config.data_source_update_sink || @config.feature_store
+        end
+
+        #
+        # Requestors provided by application code may not be able to report the response headers.
+        #
+        # @return [Array(Hash, HTTP::Headers, nil)]
+        #
+        private def request_all_data
+          return @requestor.request_all_data_with_headers if @requestor.respond_to?(:request_all_data_with_headers)
+
+          [@requestor.request_all_data, nil]
         end
 
         #

--- a/lib/ldclient-rb/impl/data_source/requestor.rb
+++ b/lib/ldclient-rb/impl/data_source/requestor.rb
@@ -40,8 +40,18 @@ module LaunchDarkly
         end
 
         def request_all_data()
-          all_data = JSON.parse(make_request("/sdk/latest-all"), symbolize_names: true)
-          Impl::Model.make_all_store_data(all_data, @config.logger)
+          request_all_data_with_headers.first
+        end
+
+        #
+        # Requests the full data set, also returning the headers of the response it was retrieved from.
+        #
+        # @return [Array(Hash, HTTP::Headers)]
+        #
+        def request_all_data_with_headers
+          body, headers = make_request("/sdk/latest-all")
+          all_data = JSON.parse(body, symbolize_names: true)
+          [Impl::Model.make_all_store_data(all_data, @config.logger), headers]
         end
 
         def stop
@@ -80,7 +90,7 @@ module LaunchDarkly
             etag = response.headers["etag"]
             @cache.write(uri, CacheEntry.new(etag, body)) unless etag.nil?
           end
-          body
+          [body, response.headers]
         end
 
         def fix_encoding(body, content_type)

--- a/lib/ldclient-rb/impl/data_source/stream.rb
+++ b/lib/ldclient-rb/impl/data_source/stream.rb
@@ -1,3 +1,4 @@
+require "ldclient-rb/impl/data_source"
 require "ldclient-rb/impl/model/serialization"
 require "ldclient-rb/impl/util"
 require "ldclient-rb/in_memory_store"
@@ -54,6 +55,7 @@ module LaunchDarkly
 
           uri = Impl::Util.add_payload_filter_key(@config.stream_uri + "/all", @config)
           @es = SSE::Client.new(uri, **opts) do |conn|
+            conn.on_connect { |response_headers| DataSource.record_environment_id(@data_source_update_sink, response_headers) }
             conn.on_event { |event| process_message(event) }
             conn.on_error { |err|
               log_connection_result(false)

--- a/lib/ldclient-rb/impl/data_system.rb
+++ b/lib/ldclient-rb/impl/data_system.rb
@@ -120,6 +120,15 @@ module LaunchDarkly
       end
 
       #
+      # Returns the ID of the environment the SDK is connected to, if LaunchDarkly has reported one.
+      #
+      # @return [String, nil]
+      #
+      def environment_id
+        raise NotImplementedError, "#{self.class} must implement #environment_id"
+      end
+
+      #
       # Represents the availability of data in the SDK.
       #
       class DataAvailability

--- a/lib/ldclient-rb/impl/data_system/fdv1.rb
+++ b/lib/ldclient-rb/impl/data_system/fdv1.rb
@@ -121,6 +121,11 @@ module LaunchDarkly
           @flag_change_broadcaster
         end
 
+        # (see DataSystem#environment_id)
+        def environment_id
+          @data_source_update_sink.environment_id
+        end
+
         #
         # (see DataSystem#data_availability)
         #

--- a/lib/ldclient-rb/impl/data_system/fdv2.rb
+++ b/lib/ldclient-rb/impl/data_system/fdv2.rb
@@ -100,6 +100,9 @@ module LaunchDarkly
             @store.with_persistence(wrapper, writable, @data_store_status_provider)
           end
 
+          @environment_id = nil
+          @environment_id_lock = Mutex.new
+
           # Threading
           @stop_event = Concurrent::Event.new
           @ready_event = Concurrent::Event.new
@@ -183,6 +186,11 @@ module LaunchDarkly
         # (see DataSystem#flag_change_broadcaster)
         def flag_change_broadcaster
           @flag_change_broadcaster
+        end
+
+        # (see DataSystem#environment_id)
+        def environment_id
+          @environment_id_lock.synchronize { @environment_id }
         end
 
         # (see DataSystem#data_availability)
@@ -270,6 +278,7 @@ module LaunchDarkly
               if basis_result.success?
                 basis = basis_result.value
                 @logger.info { "[LDClient] Initialized via #{initializer.name}" }
+                record_environment_id(basis.environment_id)
 
                 # Apply the basis to the store regardless of whether fallback was signalled.
                 # If the server returned a valid payload alongside the directive we still want
@@ -460,7 +469,10 @@ module LaunchDarkly
               @store.apply(update.change_set, true) if update.change_set
 
               # Set ready event on valid update
-              @ready_event.set if update.state == LaunchDarkly::Interfaces::DataSource::Status::VALID
+              if update.state == LaunchDarkly::Interfaces::DataSource::Status::VALID
+                @ready_event.set
+                record_environment_id(update.environment_id)
+              end
 
               # Update status
               @data_source_status_provider.update_status(update.state, update.error)
@@ -479,6 +491,18 @@ module LaunchDarkly
           end
 
           SyncResult::REMOVE
+        end
+
+        #
+        # Retains the environment ID reported by a successful connection to LaunchDarkly.
+        #
+        # @param environment_id [String, nil]
+        # @return [void]
+        #
+        def record_environment_id(environment_id)
+          return unless environment_id.is_a?(String) && !environment_id.empty?
+
+          @environment_id_lock.synchronize { @environment_id = environment_id }
         end
 
         #

--- a/lib/ldclient-rb/interfaces/hooks.rb
+++ b/lib/ldclient-rb/interfaces/hooks.rb
@@ -71,16 +71,26 @@ module LaunchDarkly
         attr_reader :method
 
         #
+        # The ID of the LaunchDarkly environment the SDK is connected to, if known. This is only available once the
+        # SDK has received data from LaunchDarkly.
+        #
+        # @return [String, nil]
+        #
+        attr_reader :environment_id
+
+        #
         # @param key [String]
         # @param context [LaunchDarkly::LDContext]
         # @param default_value [any]
         # @param method [Symbol]
+        # @param environment_id [String, nil]
         #
-        def initialize(key, context, default_value, method)
+        def initialize(key, context, default_value, method, environment_id = nil)
           @key = key
           @context = context
           @default_value = default_value
           @method = method
+          @environment_id = environment_id
         end
       end
     end

--- a/lib/ldclient-rb/ldclient.rb
+++ b/lib/ldclient-rb/ldclient.rb
@@ -421,7 +421,7 @@ module LaunchDarkly
       # Hooks can be added and we want to ensure all correct stages for a given hook execute. For example, we do not
       # want to trigger the after_evaluation method without also triggering the before_evaluation method.
       hooks = @hooks.dup
-      evaluation_series_context = Interfaces::Hooks::EvaluationSeriesContext.new(key, context, default, method)
+      evaluation_series_context = Interfaces::Hooks::EvaluationSeriesContext.new(key, context, default, method, @data_system.environment_id)
 
       [hooks, evaluation_series_context]
     end

--- a/spec/impl/data_source/polling_spec.rb
+++ b/spec/impl/data_source/polling_spec.rb
@@ -84,6 +84,43 @@ module LaunchDarkly
       end
     end
 
+    describe 'environment ID' do
+      flag = Impl::Model::FeatureFlag.new({ key: 'flagkey', version: 1 })
+      all_data = {
+        Impl::DataStore::FEATURES => { flagkey: flag },
+        Impl::DataStore::SEGMENTS => {},
+      }
+
+      it 'is recorded from the response headers' do
+        allow(requestor).to receive(:request_all_data_with_headers).and_return([all_data, { "X-LD-EnvID" => "env-abc" }])
+        store = InMemoryFeatureStore.new
+        with_processor(store) do |processor|
+          config = processor.instance_variable_get(:@config)
+          processor.start.wait
+          expect(config.data_source_update_sink.environment_id).to eq("env-abc")
+        end
+      end
+
+      it 'is not recorded when the header is absent' do
+        allow(requestor).to receive(:request_all_data_with_headers).and_return([all_data, {}])
+        store = InMemoryFeatureStore.new
+        with_processor(store) do |processor|
+          config = processor.instance_variable_get(:@config)
+          processor.start.wait
+          expect(config.data_source_update_sink.environment_id).to be_nil
+        end
+      end
+
+      it 'is not recorded for an error response' do
+        allow(requestor).to receive(:request_all_data_with_headers).and_raise(Impl::DataSource::UnexpectedResponseError.new(503))
+        with_processor(InMemoryFeatureStore.new, true) do |processor|
+          config = processor.instance_variable_get(:@config)
+          processor.start.wait(1)
+          expect(config.data_source_update_sink.environment_id).to be_nil
+        end
+      end
+    end
+
     describe 'connection error' do
       it 'does not cause immediate failure, does not set initialized' do
         allow(requestor).to receive(:request_all_data).and_raise(StandardError.new("test error"))

--- a/spec/impl/data_source/requestor_spec.rb
+++ b/spec/impl/data_source/requestor_spec.rb
@@ -46,6 +46,18 @@ module LaunchDarkly
         end
       end
 
+      it "returns the response headers" do
+        expected_data = DataSetBuilder.new.flag(FlagBuilder.new("x").build)
+        with_server do |server|
+          with_requestor(server.base_uri.to_s) do |requestor|
+            server.setup_ok_response("/", expected_data.to_json, "application/json", { "X-LD-EnvID" => "env-abc" })
+            data, headers = requestor.request_all_data_with_headers
+            expect(data).to eq expected_data.to_store_data
+            expect(headers["X-LD-EnvID"]).to eq "env-abc"
+          end
+        end
+      end
+
       it "logs debug output" do
         logger = ::Logger.new($stdout)
         logger.level = ::Logger::DEBUG

--- a/spec/impl/data_source/stream_spec.rb
+++ b/spec/impl/data_source/stream_spec.rb
@@ -68,6 +68,39 @@ module LaunchDarkly
       end
     end
 
+    describe 'environment ID' do
+      def with_connect_handler(processor)
+        connection = double("connection", on_event: nil, on_error: nil)
+        handler = nil
+        allow(connection).to receive(:on_connect) { |&block| handler = block }
+        allow(SSE::Client).to receive(:new) do |_uri, **_opts, &block|
+          block.call(connection)
+          double("SSE::Client", close: nil)
+        end
+
+        processor.start
+        begin
+          yield handler
+        ensure
+          processor.stop
+        end
+      end
+
+      it 'is recorded from the connection response headers' do
+        with_connect_handler(processor) do |handler|
+          handler.call({ "X-LD-EnvID" => "env-abc" })
+          expect(config.data_source_update_sink.environment_id).to eq("env-abc")
+        end
+      end
+
+      it 'is not recorded when the header is absent' do
+        with_connect_handler(processor) do |handler|
+          handler.call({})
+          expect(config.data_source_update_sink.environment_id).to be_nil
+        end
+      end
+    end
+
     describe '#log_connection_result' do
       it "logs successful connection when diagnostic_accumulator is provided" do
         diagnostic_accumulator = double("DiagnosticAccumulator")

--- a/spec/impl/data_source_spec.rb
+++ b/spec/impl/data_source_spec.rb
@@ -15,6 +15,29 @@ module LaunchDarkly
         expect(sink.current_status.last_error).to be_nil
       end
 
+      it "has no environment ID until one is reported" do
+        expect(sink.environment_id).to be_nil
+      end
+
+      it "records the environment ID from response headers" do
+        DataSource.record_environment_id(sink, { "X-LD-EnvID" => "env-abc" })
+        expect(sink.environment_id).to eq("env-abc")
+      end
+
+      it "ignores responses without a usable environment ID" do
+        DataSource.record_environment_id(sink, nil)
+        DataSource.record_environment_id(sink, {})
+        DataSource.record_environment_id(sink, { "X-LD-EnvID" => "" })
+        expect(sink.environment_id).to be_nil
+      end
+
+      it "does not overwrite a known environment ID with an unusable one" do
+        DataSource.record_environment_id(sink, { "X-LD-EnvID" => "env-abc" })
+        DataSource.record_environment_id(sink, { "X-LD-EnvID" => "" })
+        DataSource.record_environment_id(sink, {})
+        expect(sink.environment_id).to eq("env-abc")
+      end
+
       it "setting status to interrupted while initializing maintains initializing state" do
         sink.update_status(LaunchDarkly::Interfaces::DataSource::Status::INTERRUPTED, nil)
         expect(sink.current_status.state).to eq(LaunchDarkly::Interfaces::DataSource::Status::INITIALIZING)

--- a/spec/impl/data_system/fdv2_datasystem_spec.rb
+++ b/spec/impl/data_system/fdv2_datasystem_spec.rb
@@ -125,6 +125,95 @@ module LaunchDarkly
           end
         end
 
+        describe "environment ID" do
+          def basis_with_environment_id(environment_id)
+            LaunchDarkly::Interfaces::DataSystem::FetchResult.new(
+              result: LaunchDarkly::Result.success(
+                LaunchDarkly::Interfaces::DataSystem::Basis.new(
+                  change_set: LaunchDarkly::Interfaces::DataSystem::ChangeSetBuilder.empty(
+                    LaunchDarkly::Interfaces::DataSystem::Selector.new(state: "state", version: 1)
+                  ),
+                  persist: true,
+                  environment_id: environment_id
+                )
+              )
+            )
+          end
+
+          def mock_initializer(fetch_result)
+            initializer = double("initializer")
+            allow(initializer).to receive(:name).and_return("mock-initializer")
+            allow(initializer).to receive(:fetch).and_return(fetch_result)
+            initializer
+          end
+
+          def mock_synchronizer(updates)
+            synchronizer = double("synchronizer")
+            allow(synchronizer).to receive(:name).and_return("mock-synchronizer")
+            allow(synchronizer).to receive(:stop)
+            allow(synchronizer).to receive(:sync) { |_store, &block| updates.each { |update| block.call(update) } }
+            synchronizer
+          end
+
+          def with_data_system(initializers, synchronizers)
+            data_system_config = LaunchDarkly::DataSystem::ConfigBuilder.new
+              .initializers(initializers)
+              .synchronizers(synchronizers)
+              .build
+
+            fdv2 = FDv2.new(sdk_key, config, data_system_config)
+            begin
+              fdv2.start.wait(2)
+              yield fdv2
+            ensure
+              fdv2.stop
+            end
+          end
+
+          it "is not available before initialization" do
+            td = LaunchDarkly::Integrations::TestDataV2.data_source
+            data_system_config = LaunchDarkly::DataSystem::ConfigBuilder.new
+              .initializers(nil)
+              .synchronizers([td.test_data_ds_builder])
+              .build
+
+            fdv2 = FDv2.new(sdk_key, config, data_system_config)
+            expect(fdv2.environment_id).to be_nil
+          end
+
+          it "is retained from the initializer basis" do
+            with_data_system([MockBuilder.new(mock_initializer(basis_with_environment_id("env-abc")))], []) do |fdv2|
+              expect(fdv2.environment_id).to eq("env-abc")
+            end
+          end
+
+          it "is retained from a valid synchronizer update" do
+            update = LaunchDarkly::Interfaces::DataSystem::Update.new(
+              state: LaunchDarkly::Interfaces::DataSource::Status::VALID,
+              environment_id: "env-abc"
+            )
+
+            with_data_system(nil, [MockBuilder.new(mock_synchronizer([update]))]) do |fdv2|
+              expect(fdv2.environment_id).to eq("env-abc")
+            end
+          end
+
+          it "ignores updates without a usable environment ID" do
+            interrupted = LaunchDarkly::Interfaces::DataSystem::Update.new(
+              state: LaunchDarkly::Interfaces::DataSource::Status::INTERRUPTED,
+              environment_id: "env-from-error"
+            )
+            valid = LaunchDarkly::Interfaces::DataSystem::Update.new(
+              state: LaunchDarkly::Interfaces::DataSource::Status::VALID,
+              environment_id: ""
+            )
+
+            with_data_system(nil, [MockBuilder.new(mock_synchronizer([interrupted, valid]))]) do |fdv2|
+              expect(fdv2.environment_id).to be_nil
+            end
+          end
+        end
+
         describe "secondary synchronizer fallback" do
           it "falls back to secondary synchronizer when primary fails" do
             mock_primary = double("primary_synchronizer")

--- a/spec/ldclient_hooks_spec.rb
+++ b/spec/ldclient_hooks_spec.rb
@@ -1,5 +1,6 @@
 require "ldclient-rb"
 
+require "http_util"
 require "mock_components"
 require "model_builders"
 require "spec_helper"
@@ -112,6 +113,37 @@ module LaunchDarkly
           expect(detail.value).to eq "value"
           expect(detail.variation_index).to eq 0
           expect(detail.reason).to eq EvaluationReason::fallthrough
+        end
+      end
+
+      it "hook receives no environment ID when LaunchDarkly has not reported one" do
+        environment_id = :unset
+        config_hook = MockHook.new(->(_, _) { }, ->(series_context, _, _) { environment_id = series_context.environment_id })
+        with_client(test_config(hooks: [config_hook])) do |client|
+          client.variation("doesntmatter", basic_context, "default")
+
+          expect(environment_id).to be_nil
+        end
+      end
+
+      it "hook receives the environment ID reported by LaunchDarkly" do
+        environment_id = nil
+        config_hook = MockHook.new(->(_, _) { }, ->(series_context, _, _) { environment_id = series_context.environment_id })
+
+        with_server do |poll_server|
+          poll_server.setup_ok_response("/sdk/latest-all", { flags: {}, segments: {} }.to_json, "application/json", { "X-LD-EnvID" => "env-abc" })
+
+          config = test_config(
+            stream: false,
+            data_source: nil,
+            base_uri: poll_server.base_uri.to_s,
+            hooks: [config_hook]
+          )
+          with_client(config) do |client|
+            client.variation("doesntmatter", basic_context, "default")
+
+            expect(environment_id).to eq "env-abc"
+          end
         end
       end
 


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Part of the cross-SDK work to expose the LaunchDarkly environment ID on hook contexts, per the [hooks](https://github.com/launchdarkly/sdk-specs/blob/main/specs/HOOK-hooks/README.md) and [OTEL](https://github.com/launchdarkly/sdk-specs/blob/main/specs/OTEL-openteletry-integration/README.md) specs. Equivalent implementations: launchdarkly/dotnet-core#81, launchdarkly/python-server-sdk#484, launchdarkly/cpp-sdks#594.

**Describe the solution you've provided**

`EvaluationSeriesContext` gains an optional `environment_id`, populated by `LDClient` from the active data system:

```ruby
Interfaces::Hooks::EvaluationSeriesContext.new(key, context, default, method, @data_system.environment_id)
```

Both data systems now report it, so the value is only visible once LaunchDarkly has actually answered:

- FDv1 — `X-LD-EnvID` is read from the streaming connection response headers (`SSE::Client#on_connect`) and from polling responses (`Requestor#request_all_data_with_headers`), then recorded on the data source `UpdateSink`, which the FDv1 data system exposes.
- FDv2 — the ID was already parsed into `Basis`/`Update` by the polling and streaming data sources but discarded; the FDv2 data system now latches it from a successful initializer basis and from `VALID` synchronizer updates. This also covers the FDv1 fallback synchronizer, which reports headers the same way.

Error responses, missing headers, and empty header values are ignored and never clear a previously known ID.

The contract test service reports `environmentId` on the evaluation series context and declares the `hook-environment-id` capability.

**Describe alternatives you've considered**

A shared environment-ID holder threaded into each data source was rejected as a side channel; carrying the value with the data/response metadata matches the other SDKs and the existing FDv2 `Basis`/`Update` shape.

**Additional context**

- No `ld-eventsource` change is needed: `SSE::Client#on_connect` already yields the successful response headers on every connection and reconnection.
- `hooks/evaluation/provides the environment ID` passes against the released v2.39.0 harness (default/streaming and polling modes). The repo's v3 contract-test run is pinned to `v3.0.0-alpha.6`, which predates that test; bumping the pin can be a separate `ci:` change.
- `ruby-server-sdk-otel`'s tracing hook only uses the configured environment ID today; adding the series-context fallback is a follow-up in that repo.


Link to Devin session: https://app.devin.ai/sessions/bfe54128e2804a96bb100e6120e9a3ef
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Evaluation hooks now get an optional `environment_id` on `EvaluationSeriesContext`, filled from the active data system after LaunchDarkly reports it.
> 
> **FDv1** reads `X-LD-EnvID` from streaming connect headers and polling responses (`request_all_data_with_headers`) and stores it on the data-source update sink. **FDv2** latches the ID from a successful initializer `Basis` and from `VALID` synchronizer updates (it was already on those types but unused). Missing, empty, or error-path values are ignored and never clear a known ID.
> 
> Contract tests declare `hook-environment-id` and include `environmentId` in hook callbacks. CI v3 contract tests now pin to `v3` instead of `v3.0.0-alpha.6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a713037bd29d51e7e90940520ff2da2496e9adce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->