### PR TITLE
fix: Escape attribute names reported in redactedAttributes

### DIFF
--- a/lib/ldclient-rb/impl/context_filter.rb
+++ b/lib/ldclient-rb/impl/context_filter.rb
@@ -100,18 +100,29 @@ module LaunchDarkly
       #
       private def check_whole_attribute_private(attribute, private_attributes, redacted, redact_all)
         if @all_attributes_private || redact_all
-          redacted << attribute
+          redacted << redaction_name(attribute)
           return true
         end
 
         private_attributes.each do |private_attribute|
           if private_attribute.component(0) == attribute && private_attribute.depth == 1
-            redacted << attribute
+            redacted << redaction_name(attribute)
             return true
           end
         end
 
         false
+      end
+
+      #
+      # Convert an attribute name into the attribute reference used to report it
+      # as redacted.
+      #
+      # @param attribute [Symbol]
+      # @return [Symbol]
+      #
+      private def redaction_name(attribute)
+        LaunchDarkly::Reference.create_literal(attribute).raw_path.to_sym
       end
 
       #

--- a/spec/impl/context_filter_spec.rb
+++ b/spec/impl/context_filter_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+module LaunchDarkly
+  module Impl
+    describe ContextFilter do
+      it "reports redacted attribute names as escaped attribute references" do
+        filter = ContextFilter.new(true, [])
+        context = LDContext.create({ kind: "user", key: "user-key", :"/ssn" => "123-45-6789", :"a/b~c" => "value" })
+
+        filtered = filter.filter(context)
+
+        expect(filtered[:_meta][:redactedAttributes]).to contain_exactly(:"/~1ssn", :"a/b~c")
+      end
+
+      it "escapes redacted attribute names when redacting anonymous contexts" do
+        filter = ContextFilter.new(false, [])
+        context = LDContext.create({ kind: "user", key: "user-key", anonymous: true, name: "name", :"/ssn" => "123-45-6789" })
+
+        filtered = filter.filter_redact_anonymous(context)
+
+        expect(filtered[:_meta][:redactedAttributes]).to contain_exactly(:name, :"/~1ssn")
+      end
+
+      it "escapes redacted attribute names configured as private" do
+        filter = ContextFilter.new(false, ["/~1ssn"])
+        context = LDContext.create({ kind: "user", key: "user-key", :"/ssn" => "123-45-6789", name: "name" })
+
+        filtered = filter.filter(context)
+
+        expect(filtered[:name]).to eq("name")
+        expect(filtered[:_meta][:redactedAttributes]).to eq([:"/~1ssn"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Surfaced by contract test harness v3.2.0-alpha.6 (the pin bump in #414). These 6 subtests failed against the newer harness:

- `events/context properties/single-kind, allAttributesPrivate, slash-prefixed attribute name` (debug, identify, index-from-evaluation, index-from-custom-event)
- `events/feature events/single-kind anonymous context redacts all attributes/type: any`
- `events/feature events/multi-kind with anonymous context redacts attributes appropriately/type: any`

**Describe the solution you've provided**

`_meta.redactedAttributes` in event payloads is a list of attribute *references*, not raw attribute names. When a context has an attribute whose name begins with `/` (e.g. `/ssn`), the SDK emitted the raw name, which a consumer parses as a path expression pointing at a nested property rather than the top-level attribute:

```
expected: "/~1ssn"
actual:   "/ssn"
```

`ContextFilter#check_whole_attribute_private` now converts the attribute name to a reference with `Reference.create_literal` before adding it to the redacted list, which escapes `/` and `~` for slash-prefixed names and leaves all other names unchanged (`name` stays `name`, `a/b~c` stays `a/b~c` since it is already a literal reference). This covers both the `allAttributesPrivate`/configured-private paths and the anonymous-context redaction path, which is why one change fixes all 6 subtests.

Verified locally: contract test service against released harness v3.2.0-alpha.6, full suite — 4723 total, 14 skipped, all ran passed.

**Describe alternatives you've considered**

Escaping only in the `all_attributes_private` branch — rejected, the same escaping is required wherever a whole attribute is redacted.

**Additional context**

Nested redactions (`redact_json_value`) already reported `Reference#raw_path`, so they were unaffected.


Link to Devin session: https://app.devin.ai/sessions/316afaccd2604f8d802a72c9080f6921
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes **`_meta.redactedAttributes`** in event payloads so entries are **escaped attribute references**, not raw names. Attributes whose names start with `/` (e.g. `/ssn`) were emitted as `/ssn`, which consumers parse as a nested path instead of a top-level literal.
> 
> **`ContextFilter`** now passes **`Reference.create_literal`** into **`check_whole_attribute_private`** for `name` and custom attributes, and records **`attribute.raw_path.to_sym`** in the redacted list. That aligns whole-attribute redaction with **`redact_json_value`**, which already used **`raw_path`**.
> 
> The same path covers **all-attributes-private**, **configured private attributes**, and **anonymous context** redaction. Tests assert escaped values such as `"/~1ssn"` for slash-prefixed names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5814e950eaaa9430a3a5c0f243897e1cd4acb809. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->