### PR TITLE
fix: Stop per-context private attributes from accumulating between contexts

### DIFF
--- a/lib/ldclient-rb/impl/context_filter.rb
+++ b/lib/ldclient-rb/impl/context_filter.rb
@@ -70,7 +70,7 @@ module LaunchDarkly
         filtered[:anonymous] = true if anonymous
 
         redacted = []
-        private_attributes = @private_attributes.concat(context.private_attributes)
+        private_attributes = @private_attributes + context.private_attributes
 
         name = context.get_value(:name)
         if !name.nil? && !check_whole_attribute_private(:name, private_attributes, redacted, anonymous && redact_anonymous)

--- a/spec/impl/context_filter_spec.rb
+++ b/spec/impl/context_filter_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+module LaunchDarkly
+  module Impl
+    describe ContextFilter do
+      it "does not apply per-context private attributes to later contexts" do
+        filter = ContextFilter.new(false, [])
+        private_context = LDContext.create({ kind: "user", key: "user-key", email: "email", _meta: { privateAttributes: ["email"] } })
+        other_context = LDContext.create({ kind: "user", key: "other-key", email: "email" })
+
+        expect(filter.filter(private_context)[:_meta][:redactedAttributes]).to eq([:email])
+        expect(filter.filter(other_context)).to eq({ key: "other-key", kind: "user", email: "email" })
+      end
+
+      it "does not apply private attributes of one kind to the other kinds of a multi-kind context" do
+        filter = ContextFilter.new(false, [])
+        context = LDContext.create_multi([
+                                           LDContext.create({ kind: "user", key: "user-key", email: "email", _meta: { privateAttributes: ["email"] } }),
+          LDContext.create({ kind: "org", key: "org-key", email: "email" }),
+                                         ])
+
+        filtered = filter.filter(context)
+
+        expect(filtered["user"][:_meta][:redactedAttributes]).to eq([:email])
+        expect(filtered["org"]).to eq({ key: "org-key", email: "email" })
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Found while investigating the contract test failures fixed in #415. Not covered by the current contract test suite.

**Describe the solution you've provided**

`ContextFilter#filter_single_context` combined the globally configured private attributes with the context's own `_meta.privateAttributes` using `Array#concat`, which mutates `@private_attributes` in place. Every context filtered by a `ContextFilter` therefore permanently added its private attributes to the filter's configuration, so a context's private attributes were applied to all contexts filtered afterwards — including the other kinds of the same multi-kind context.

Before (single `ContextFilter.new(false, [])`):

```ruby
filter.filter(user_with_private_email)  # {..., _meta: {redactedAttributes: [:email]}}
filter.filter(other_user)               # {..., _meta: {redactedAttributes: [:email]}}  <- email was not private here
```

The fix builds a new array (`@private_attributes + context.private_attributes`) instead of mutating the configured list. Event processors reuse a single `ContextFilter` for the lifetime of the client, so the leak was cumulative across all events.

**Describe alternatives you've considered**

Constructing the filter per event — unnecessary allocation churn, and the mutation is the actual defect.

**Additional context**

Full contract test suite against harness v3.2.0-alpha.6 passes with this change (combined with #415): 4723 total, 14 skipped, all ran passed.


Link to Devin session: https://app.devin.ai/sessions/316afaccd2604f8d802a72c9080f6921
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Fixes a privacy bug in `ContextFilter#filter_single_context`:** merging global private attributes with each context’s `_meta.privateAttributes` used `Array#concat`, which mutated the filter’s `@private_attributes`. Because `EventOutputFormatter` keeps one `ContextFilter` for the client lifetime, later contexts (and other kinds in the same multi-kind context) could incorrectly redact attributes that were only private on a previous context.
> 
> The change uses `@private_attributes + context.private_attributes` so the configured list is never mutated. New specs cover sequential filtering and multi-kind isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 878e2e9b786e8e4395b1c7a03dcda35ce2cae4a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->