### PR TITLE
feat: Test vulnerability alert ordering with explicit config

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -37,7 +37,7 @@ runs:
 
     - name: Run contract tests v2
       if: ${{ inputs.flaky != 'true' }}
-      uses: launchdarkly/gh-actions/actions/contract-tests@5adb11fd6953e1bc35d9cf1fc1b4374c464e3a8b # contract-tests-v1
+      uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1
       with:
         test_service_port: 9000
         enable_persistence_tests: true
@@ -46,7 +46,7 @@ runs:
 
     - name: Run contract tests v3
       if: ${{ inputs.flaky != 'true' }}
-      uses: launchdarkly/gh-actions/actions/contract-tests@5adb11fd6953e1bc35d9cf1fc1b4374c464e3a8b # contract-tests-v1
+      uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1
       with:
         test_service_port: 9000
         enable_persistence_tests: true

--- a/.github/actions/publish-docs/action.yml
+++ b/.github/actions/publish-docs/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: launchdarkly/gh-actions/actions/publish-pages@f87da03e3413ce472ac621025890774ce725e373 # publish-pages-v1.0.2
+    - uses: launchdarkly/gh-actions/actions/publish-pages@publish-pages-v1
       name: 'Publish to Github pages'
       with:
         docs_path: docs/build/html/

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,4 @@
 {
-  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
-  "vulnerabilityAlerts": {
-    "enabled": true
-  },
-  "osvVulnerabilityAlerts": true
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>launchdarkly/gh-actions//renovate/sdk-ruby"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>launchdarkly/gh-actions//renovate/sdk-ruby"]
+  "extends": ["github>launchdarkly/gh-actions//renovate/sdk-ruby"],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "schedule": ["* * * * *"]
+  },
+  "osvVulnerabilityAlerts": true
 }

--- a/.github/workflows/build-gem.yml
+++ b/.github/workflows/build-gem.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: launchdarkly/gh-actions/actions/persistent-stores@68e9b2f165f60934308f18e4b75623c30b905c38 # persistent-stores-v0
+      - uses: launchdarkly/gh-actions/actions/persistent-stores@persistent-stores-v0
         with:
           redis: true
           consul: true

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   lint-pr-title:
-    uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@2e6676d8c7ed1a59114d08faa22e3dbf085a1a64 # main
+    uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -35,7 +35,7 @@ jobs:
           version: "3.2"
           install-dependencies: false
 
-      - uses: launchdarkly/gh-actions/actions/release-secrets@bbbbbda684f500766264e7fe327668094ba83d1c # release-secrets-v1.2.0
+      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1
         name: "Get rubygems API key"
         if: ${{ format('{0}', inputs.dry_run) == 'false' }}
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,7 +52,7 @@ jobs:
           version: "3.2"
           install-dependencies: false
 
-      - uses: launchdarkly/gh-actions/actions/release-secrets@bbbbbda684f500766264e7fe327668094ba83d1c # release-secrets-v1.2.0
+      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1
         name: "Get rubygems API key"
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   sdk-close-stale:
-    uses: launchdarkly/gh-actions/.github/workflows/sdk-stale.yml@2e6676d8c7ed1a59114d08faa22e3dbf085a1a64 # main
+    uses: launchdarkly/gh-actions/.github/workflows/sdk-stale.yml@main


### PR DESCRIPTION
## Summary

- Adds explicit `vulnerabilityAlerts` and `osvVulnerabilityAlerts` config at the repo level, after the preset's `enabled: false` packageRule
- Testing whether this ordering causes Renovate to create security update PRs for bundler packages with known CVEs

## Context

The `sdk-ruby` preset sets `enabled: false` for all bundler packages to suppress routine dependency PRs. However, Renovate's vulnerability alert system should bypass `enabled: false` via a `force` mechanism. The log from js-core showed that npm packages with known CVEs were logged as "is disabled" rather than generating PRs.

This PR tests whether explicitly re-declaring `vulnerabilityAlerts.enabled: true` at the repo level (after the preset extends) changes the behavior.