### PR TITLE
fix: Send the FDv2 polling selector as the "basis" query parameter

### DIFF
--- a/lib/ldclient-rb/impl/data_system/polling.rb
+++ b/lib/ldclient-rb/impl/data_system/polling.rb
@@ -313,7 +313,7 @@ module LaunchDarkly
           query_params << ["filter", @config.payload_filter_key] unless @config.payload_filter_key.nil?
 
           if selector && selector.defined?
-            query_params << ["selector", selector.state]
+            query_params << ["basis", selector.state]
           end
 
           uri = @poll_uri


### PR DESCRIPTION
## What

The FDv2 (data system v2) polling requester (`HTTPPollingRequester`) was attaching the current payload selector's state to the poll request under the query-parameter name `selector`. The protocol requires this parameter to be named `basis`. Because the server silently ignores unknown query parameters, it never received the SDK's current basis, so every poll returned a full payload and delta polling never engaged.

## Fix

Rename the polling query parameter from `selector` to `basis` (the value — the selector's `state` — is unchanged, and it is still only sent when a selector is present). This matches:

- The CSFDV2 spec, which requires the `basis` query parameter carrying the `state` from the most recent `payload-transferred` event.
- The Go server SDK (`params["basis"] = selector.State()`) and the recently fixed Python SDK.
- Ruby's own FDv2 **streaming** requester, which already sends `basis`.

FDv1 polling (`HTTPFDv1PollingRequester`) does not send a selector/basis and is unaffected.

## Testing

This was surfaced by a new sdk-test-harness FDv2 polling `basis` contract test. The existing polling unit specs (`polling_synchronizer_spec.rb`, `polling_initializer_spec.rb`, 39 examples) use mock requesters and continue to pass; none asserted the query-string parameter name, so no unit test change was needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **FDv2 polling** now sends the current selector state on poll requests using the **`basis`** query parameter instead of **`selector`**, matching the CSFDV2 protocol and aligning with FDv2 streaming and other SDKs.
> 
> The value (`selector.state`) and the condition (only when a defined selector exists) are unchanged. **FDv1 polling** does not send this parameter and is unaffected.
> 
> Without this fix, the server ignored the unknown `selector` parameter, so polls always returned full payloads and **delta polling never engaged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea2f2e8d98ae30b5710167e01b8e7bd238e86607. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->