### PR TITLE
ci: Run RuboCop serially to avoid JRuby thread-parallel failures

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -23,7 +23,7 @@ runs:
 
     - name: Run RuboCop
       shell: bash
-      run: bundle exec rubocop --parallel
+      run: bundle exec rubocop
 
     - name: Build contract tests
       if: ${{ inputs.flaky != 'true' }}


### PR DESCRIPTION
Run RuboCop serially, mirroring launchdarkly/openfeature-ruby-server#34, because `--parallel` is broken under JRuby as of RuboCop 1.90.0.

- The shared `check` composite action runs on `jruby-9.4`, and the gemspec's `rubocop "~> 1.76"` floats to 1.90.0 (released 2026-08-24), so this repo is exposed to the same failure
- Parallelism buys little here, and the CRuby jobs only lose a negligible speedup

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

launchdarkly/openfeature-ruby-server#34

<details>
<summary>Implementation details</summary>

**Root cause** (from the investigation in openfeature-ruby-server#34)

Under JRuby the `parallel` gem cannot fork, so it runs work in threads instead of worker processes. RuboCop 1.90 began preserving cop instances across files, and `RuboCop::Cop::Base` documents the assumption that each `--parallel` worker is its own process with its own cop instances. With threads that assumption breaks: reused cop instances see concurrent `processed_source` values, producing internal cop errors and phantom offenses with mismatched locations. The mechanism is a reading of the RuboCop source, not an upstream-confirmed diagnosis.

Verified there (JRuby 10.0.4/10.0.6/10.1.1 with RuboCop 1.90.0: `--parallel` fails, serial clean; RuboCop 1.89.0: both clean), so no JRuby upgrade avoids it and pinning RuboCop only defers it.

**Scope**

Only `.github/actions/check/action.yml` changes; that action is used by `ci.yml`, `build-gem.yml`, `release-please.yml`, and the manual publish workflows, so all of them pick up the serial run.

**Alternatives considered**

- Pin `rubocop` to `~> 1.89.0`: hides the problem and freezes lint at an old version.
- Skip RuboCop on JRuby: works, but drops JRuby-specific lint coverage for no benefit over running serially.

</details>


Link to Devin session: https://app.devin.ai/sessions/feaff386987f4b3db39becb95bce9fa4
Open in Devin Desktop: https://app.devin.ai/desktop/session/feaff386987f4b3db39becb95bce9fa4?variant=devin
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> The shared **Quality control checks** composite action (`.github/actions/check/action.yml`) now runs `bundle exec rubocop` without `--parallel`, so RuboCop executes serially on every workflow that uses this action (CI, gem build, release, etc.).
> 
> This avoids JRuby CI failures introduced with RuboCop 1.90, where thread-based “parallel” workers reuse cop instances and trigger internal errors and bogus offenses; serial execution matches the fix used in launchdarkly/openfeature-ruby-server#34.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b0080f7321aab3a06819e0c8465a64abfadba5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->