### PR TITLE
ci: Apply a Bundler cooldown to dependency resolution

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -23,7 +23,7 @@ runs:
 
     - name: Run RuboCop
       shell: bash
-      run: bundle exec rubocop --parallel
+      run: bundle exec rubocop
 
     - name: Build contract tests
       if: ${{ inputs.flaky != 'true' }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,7 +15,8 @@ runs:
     - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
       with:
         ruby-version: ${{ inputs.version }}
-        bundler: 2
+        # The Gemfile cooldown needs Bundler 4, which requires Ruby 3.2 or later.
+        bundler: ${{ startsWith(inputs.version, 'jruby-9') && '2' || '4.0.19' }}
 
     - name: Install dependencies
       if: ${{ inputs.install-dependencies == 'true' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ We encourage pull requests and other contributions from the community. Before su
 
 This SDK is built with [Bundler](https://bundler.io/). To install Bundler, run `gem install bundler`. You might need `sudo` to execute the command successfully.
 
+The `Gemfile` declares a [cooldown](https://blog.rubygems.org/2026/06/03/cooldown-let-new-gems-be-vetted.html), so dependencies only resolve to versions that have been published for at least seven days. `ld-eventsource` is exempt, because we publish it ourselves and generally want to build against a release immediately. Cooldown requires Bundler 4.0.13 or later; older versions ignore the setting and resolve to the newest matching version. Pass `--cooldown 0` to reach a version inside the window, for instance when a security fix has just been released.
+
 To install the runtime dependencies:
 
 ```

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,9 @@
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 7
 
 gemspec
+
+# Cooldown is configured per source, so exempting our own libraries from it
+# requires a second remote for the same registry.
+source "https://index.rubygems.org", cooldown: 0 do
+  gem "ld-eventsource"
+end


### PR DESCRIPTION
Resolve dependencies only to gem versions that have been public for at least seven days, using Bundler's [cooldown](https://blog.rubygems.org/2026/06/03/cooldown-let-new-gems-be-vetted.html). Equivalent of launchdarkly/openfeature-ruby-server#35.

- No pinning and no lockfile: we still get the newest version matching each constraint, just not one published in the last week
- `ld-eventsource` is exempt, so the exact-version bump right after one of its releases still resolves
- Requires Bundler >= 4.0.13, so CI pins Bundler to 4.0.19 — except on `jruby-9.4`, which is Ruby 3.1 and cannot install Bundler 4 at all, so it stays on Bundler 2 and resolves without a cooldown
- Because that job has no cooldown, this PR also runs RuboCop serially (openfeature-ruby-server#34): `--parallel` is broken under JRuby as of RuboCop 1.90.0, which the `jruby-9.4` job picks up regardless
- Contributors on Bundler 2.x are unaffected — the setting is silently ignored, so they simply resolve to the newest versions

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Port of launchdarkly/openfeature-ruby-server#35 and, for the RuboCop step, launchdarkly/openfeature-ruby-server#34.

<details>
<summary>Implementation details</summary>

**How cooldown works**

`source "https://rubygems.org", cooldown: 7` makes Bundler consult the per-version `created_at` timestamp in rubygems.org's v2 compact index during resolution and pass over any version younger than the window. Versions whose source does not expose `created_at` (private registries, pre-v2 entries) stay resolvable, so this never silently blocks a resolution. `--cooldown 0` / `BUNDLE_COOLDOWN=0` is the escape hatch when the newest release is exactly the one you want, e.g. a security fix.

**Why the second source block**

Cooldown is stored per remote URI (`Bundler::Source::Rubygems#remote_cooldowns`), with no per-gem option, and a second `source` block for the *same* URI does not get its own value. Naming the registry's index host gives a distinct remote that can carry `cooldown: 0`:

```ruby
source "https://index.rubygems.org", cooldown: 0 do
  gem "ld-eventsource"
end
```

The gemspec requires `ld-eventsource` at an exact version, deliberately, so that bugfixes there are always tied to a new SDK version. Without the exemption, the first seven days after each `ld-eventsource` release would be un-resolvable: every candidate satisfying the new exact constraint is inside the cooldown window. Exempting it is also the right policy — we publish that gem, so it is not the untrusted-third-party case cooldown defends against.

**The `jruby-9.4` exception, and the RuboCop step**

Bundler 4.0.19 requires Ruby >= 3.2, and JRuby 9.4 reports `RUBY_VERSION` 3.1.7:

```
ERROR:  Error installing bundler:
	bundler-4.0.19 requires Ruby version >= 3.2.0. The current ruby version is 3.1.7.
```

So the shared setup action selects the Bundler version per runtime rather than pinning one for all of them, and the `jruby-9.4` job resolves with Bundler 2, which ignores `cooldown:`. That job therefore keeps installing brand-new gem versions — including RuboCop 1.90.0, whose `--parallel` mode is broken under JRuby, which failed the first CI run on this branch:

```
1.90.0 (using Parser 3.3.12.0, rubocop-ast 1.50.0, analyzing as Ruby 3.1, running on jruby 3.1.7) [java]
```

On JRuby the `parallel` gem cannot fork, so it runs work in threads; RuboCop 1.90 began preserving cop instances across files, and shared cop instances seeing concurrent `processed_source` values produce thousands of internal cop errors and phantom offenses. Dropping `--parallel` fixes it, and parallelism is a negligible speedup on 185 files. openfeature-ruby-server does not have the Bundler gap because its matrix is on `jruby-10.0` (Ruby 3.4); moving this repo's matrix to `jruby-10` would let cooldown apply everywhere, but that is a supported-platform change and out of scope here.

**Verification**

Ran locally in containers against this branch (no lockfile):

| Runtime | Bundler | Result |
| --- | --- | --- |
| CRuby 3.4.10 | 4.0.19 | `rubocop 1.90.0 (available in 4 days), resolved 1.89.0 instead`, same for `aws-partitions`; 1046 examples 0 failures; RuboCop clean |
| CRuby 3.2 | 4.0.19 | same cooldown skips, resolution succeeds |
| CRuby 3.4.10 | 2.6.9 | resolves the same Gemfile without error, ignoring `cooldown:` |
| JRuby 9.4.15 | 2.6.9 | resolves without error (no cooldown), RuboCop 1.90.0: `--parallel` → 37497 internal cop errors and 965 phantom offenses; serial → 185 files inspected, no offenses |

**Alternatives considered**

- Pin Bundler 4.0.19 for every job: breaks the `jruby-9.4` job outright.
- `cooldown: 3` with no exemption: shorter window, and still breaks for three days after each `ld-eventsource` release.
- Commit a `Gemfile.lock` and let Dependabot bump it with a cooldown: gives an auditable dependency history, but pins a library to specific versions and stops testing against the newest supported ones.
- `bundle config set cooldown` / `BUNDLE_COOLDOWN` in CI only: leaves local `bundle install` unprotected, and cannot express a per-source exemption.

</details>


Link to Devin session: https://app.devin.ai/sessions/9e2aad687cd743149ff71c0a1fcfd936
Open in Devin Desktop: https://app.devin.ai/desktop/session/9e2aad687cd743149ff71c0a1fcfd936?variant=devin
Requested by: @kinyoklion