### PR TITLE
ci: Quote the JRuby spec tag so the suite actually runs

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -15,11 +15,14 @@ runs:
     - name: Skip flaky tests for jruby
       if: ${{ inputs.flaky == 'true' }}
       shell: bash
-      run: echo "SPEC_TAGS=-t '~flaky'" >> $GITHUB_ENV
+      run: echo "SPEC_TAGS=~flaky" >> $GITHUB_ENV
 
+    # The tag is quoted here rather than in GITHUB_ENV. A quote written into
+    # GITHUB_ENV becomes part of the value, and a bare ~flaky would undergo
+    # tilde expansion.
     - name: Run tests
       shell: bash
-      run: bundle exec rspec spec $SPEC_TAGS
+      run: bundle exec rspec spec ${SPEC_TAGS:+--tag "$SPEC_TAGS"}
 
     - name: Run RuboCop
       shell: bash


### PR DESCRIPTION
The JRuby job has been running zero of the 1046 specs. The intent was to
skip only the three spec files tagged flaky, which is 33 examples, and run
the other 1013. Instead RuboCop was the only thing the job exercised.

GITHUB_ENV stores a value literally, so the single quotes in

  echo "SPEC_TAGS=-t '~flaky'" >> $GITHUB_ENV

became part of the value. Unquoted $SPEC_TAGS then split into -t and
'~flaky', and RSpec read a tag whose name starts with a quote rather than
a tilde. A tilde only negates as the first character, so this asked for an
inclusion filter on a tag nothing carries:

  Run options: include {:"'~flaky'"=>true}
  All examples were filtered out
  0 examples, 0 failures

Storing a bare ~flaky does not work either, because it undergoes tilde
expansion and fails with "no such user or named directory: flaky". So the
value holds the tag alone and the quoting happens where the argument is
built.

  Run options: exclude {:flaky=>true}
  1013 examples, 0 failures

Verified under bash, the shell CI uses. With SPEC_TAGS unset, which is
every CRuby and Windows job, the command still runs all 1046 examples, so
those jobs do not change.

The suite has not run on JRuby since the release-please migration in
5627f3a, dated 2023-12-01, so this exposes it there for the first time in
roughly two years. Any failures it surfaces are pre-existing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Fixes the JRuby CI job so RSpec actually runs** instead of filtering out every example. The flaky-skip path had been writing `-t '~flaky'` into `GITHUB_ENV`, which kept the quotes in the value and made RSpec look for a bogus tag—**0 of 1046 specs** ran.
> 
> The action now stores only `~flaky` in `SPEC_TAGS` and passes it at invoke time as `bundle exec rspec spec ${SPEC_TAGS:+--tag "$SPEC_TAGS"}`, so quoting avoids `GITHUB_ENV` literal-quote issues and shell tilde expansion. When `SPEC_TAGS` is unset (CRuby/Windows), the command is unchanged and still runs the full suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14beea5be32bd874c5e9378a70dbb7029daac296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->