### PR TITLE
feat: Warn when the SDK is used in a forked process without postfork

### DIFF
--- a/lib/ldclient-rb/ldclient.rb
+++ b/lib/ldclient-rb/ldclient.rb
@@ -138,10 +138,7 @@ module LaunchDarkly
       return if pid == @owner_pid
       return unless fork_breaks_client?
 
-      warned_pid = @fork_warned_pid.get
-      return if warned_pid == pid
-
-      if @fork_warned_pid.compare_and_set(warned_pid, pid)
+      if @fork_warned_pid.get_and_set(pid) != pid
         @config.logger.warn { FORK_WARNING_MESSAGE }
       end
     end

--- a/lib/ldclient-rb/ldclient.rb
+++ b/lib/ldclient-rb/ldclient.rb
@@ -33,10 +33,6 @@ module LaunchDarkly
 
     def_delegators :@config, :logger
 
-    # @!method flush
-    #   Delegates to {LaunchDarkly::EventProcessorMethods#flush}.
-    def_delegator :@event_processor, :flush
-
     # @!method data_store_status_provider
     #   Delegates to the data system {LaunchDarkly::Impl::DataSystem#data_store_status_provider}.
     #   @return [LaunchDarkly::Interfaces::DataStore::StatusProvider]
@@ -79,6 +75,12 @@ module LaunchDarkly
       config.instance_id = SecureRandom.uuid
       @config = config
 
+      # The pid of the process that owns this client's background threads. A child process that
+      # inherits this client after a fork has a different pid. See #check_forked.
+      @owner_pid = Process.pid
+      # The pid of the process in which the fork warning was last logged, or nil.
+      @fork_warned_pid = Concurrent::AtomicReference.new(nil)
+
       start_up(wait_for_sec)
     end
 
@@ -97,6 +99,10 @@ module LaunchDarkly
     # reason, it is recommended that any listener or hook integrations be added postfork unless you are certain it can
     # survive the forking process.
     #
+    # If the SDK is used in a forked child process before this method is called, it logs a warning once per process.
+    # The warning says that flag updates and analytics events will not work until `postfork` is called. Calling this
+    # method clears that condition for the current process.
+    #
     # @param wait_for_sec [Float] maximum time (in seconds) to wait for initialization
     #
     def postfork(wait_for_sec = 5)
@@ -105,7 +111,52 @@ module LaunchDarkly
       @big_segment_store_manager = nil
       @flag_tracker = nil
 
+      @owner_pid = Process.pid
+      @fork_warned_pid.set(nil)
+
       start_up(wait_for_sec)
+    end
+
+    FORK_WARNING_MESSAGE = "[LDClient] This process was forked after the LDClient was created. Background threads do not " +
+      "survive a fork, so flag updates and analytics events will not work in this process. Call LDClient#postfork after forking."
+    private_constant :FORK_WARNING_MESSAGE
+
+    #
+    # Log a warning once per process if this client is used in a process that was forked after the client was created.
+    #
+    # Ruby threads do not survive a fork. A child process that inherits a client has no stream thread, no event
+    # dispatcher thread, and no timer tasks, so flag updates and analytics events stop working. The SDK does not
+    # repair this by itself; the application must call {#postfork}.
+    #
+    # The check compares the current pid with the pid recorded in the constructor or in {#postfork}. It is a single
+    # `getpid` call, which is cheap compared to a flag evaluation. The "already warned" state is stored as the pid in
+    # which the warning was logged, not as a boolean. A boolean would be copied into every child on fork, so a
+    # grandchild process would inherit "already warned" from its parent and never get its own warning.
+    #
+    private def check_forked
+      pid = Process.pid
+      return if pid == @owner_pid
+      return unless fork_breaks_client?
+
+      warned_pid = @fork_warned_pid.get
+      return if warned_pid == pid
+
+      if @fork_warned_pid.compare_and_set(warned_pid, pid)
+        @config.logger.warn { FORK_WARNING_MESSAGE }
+      end
+    end
+
+    #
+    # Return true if this configuration needs background threads. Offline mode has none. LDD mode with events
+    # disabled reads flags from the persistent store and sends nothing, so a fork does not break it.
+    #
+    # @return [Boolean]
+    #
+    private def fork_breaks_client?
+      return false if @config.offline?
+      return false if @config.use_ldd? && !@config.send_events
+
+      true
     end
 
     private def start_up(wait_for_sec)
@@ -281,6 +332,7 @@ module LaunchDarkly
     # @return the variation for the provided context, or the default value if there's an error
     #
     def variation(key, context, default)
+      check_forked
       context = Impl::Context::make_context(context)
       result = evaluate_with_hooks(key, context, default, :variation) do
         detail, _, _ = variation_with_flag(key, context, default)
@@ -314,6 +366,7 @@ module LaunchDarkly
     # @return [EvaluationDetail] an object describing the result
     #
     def variation_detail(key, context, default)
+      check_forked
       context = Impl::Context::make_context(context)
       result = evaluate_with_hooks(key, context, default, :variation_detail) do
         detail, _, _ = evaluate_internal(key, context, default, true)
@@ -439,6 +492,7 @@ module LaunchDarkly
     # @return [Array<Symbol, Interfaces::Migrations::OpTracker>]
     #
     def migration_variation(key, context, default_stage)
+      check_forked
       unless Migrations::VALID_STAGES.include? default_stage
         @config.logger.error { "[LDClient] default_stage #{default_stage} is not a valid stage; continuing with 'off' as default" }
         default_stage = Migrations::STAGE_OFF
@@ -480,6 +534,7 @@ module LaunchDarkly
     # @return [void]
     #
     def identify(context)
+      check_forked
       context = LaunchDarkly::Impl::Context.make_context(context)
       unless context.valid?
         @config.logger.warn("Identify called with invalid context: #{context.error}")
@@ -516,6 +571,7 @@ module LaunchDarkly
     # @return [void]
     #
     def track(event_name, context, data = nil, metric_value = nil)
+      check_forked
       context = LaunchDarkly::Impl::Context.make_context(context)
       unless context.valid?
         @config.logger.warn("Track called with invalid context: #{context.error}")
@@ -536,6 +592,7 @@ module LaunchDarkly
     # @param tracker [LaunchDarkly::Interfaces::Migrations::OpTracker]
     #
     def track_migration_op(tracker)
+      check_forked
       unless tracker.is_a? LaunchDarkly::Interfaces::Migrations::OpTracker
         @config.logger.error { "invalid op tracker received in track_migration_op" }
         return
@@ -570,6 +627,8 @@ module LaunchDarkly
     #
     def all_flags_state(context, options={})
       return FeatureFlagsState.new(false) if @config.offline?
+
+      check_forked
 
       unless initialized?
         if @data_system.store.initialized?
@@ -629,10 +688,23 @@ module LaunchDarkly
     end
 
     #
+    # Tells the client that all pending analytics events should be delivered as soon as possible.
+    #
+    # Delegates to {LaunchDarkly::EventProcessorMethods#flush}.
+    #
+    # @return [void]
+    #
+    def flush
+      check_forked
+      @event_processor.flush
+    end
+
+    #
     # Releases all network connections and other resources held by the client, making it no longer usable.
     #
     # @return [void]
     def close
+      check_forked
       @config.logger.info { "[LDClient] Closing LaunchDarkly client..." }
       @data_system.stop
       @event_processor.stop

--- a/spec/ldclient_fork_spec.rb
+++ b/spec/ldclient_fork_spec.rb
@@ -1,0 +1,236 @@
+require "capturing_logger"
+require "mock_components"
+require "spec_helper"
+
+module LaunchDarkly
+  describe "LDClient fork detection" do
+    let(:logger) { CapturingLogger.new }
+    let(:context) { basic_context }
+    let(:warning_pattern) { /forked after the LDClient was created/ }
+
+    # Make Process.pid report a pid other than the one recorded by the client. The client is created before this
+    # stub is applied, so the client sees the real pid as the owner and the stubbed pid as a child.
+    def pretend_forked
+      real_pid = Process.pid
+      allow(Process).to receive(:pid).and_return(real_pid + 1)
+    end
+
+    def fork_warnings(logger)
+      logger.output.lines.grep(warning_pattern)
+    end
+
+    context "when the pid has not changed" do
+      it "does not warn" do
+        with_client(test_config(logger: logger)) do |client|
+          client.variation("flag", context, false)
+          client.identify(context)
+          client.track("event", context)
+          client.all_flags_state(context)
+          client.flush
+        end
+        expect(fork_warnings(logger)).to be_empty
+      end
+    end
+
+    context "when the pid has changed" do
+      it "warns on variation" do
+        with_client(test_config(logger: logger)) do |client|
+          pretend_forked
+          client.variation("flag", context, false)
+          expect(fork_warnings(logger).length).to eq(1)
+        end
+      end
+
+      it "warns on variation_detail" do
+        with_client(test_config(logger: logger)) do |client|
+          pretend_forked
+          client.variation_detail("flag", context, false)
+          expect(fork_warnings(logger).length).to eq(1)
+        end
+      end
+
+      it "warns on all_flags_state" do
+        with_client(test_config(logger: logger)) do |client|
+          pretend_forked
+          client.all_flags_state(context)
+          expect(fork_warnings(logger).length).to eq(1)
+        end
+      end
+
+      it "warns on migration_variation" do
+        with_client(test_config(logger: logger)) do |client|
+          pretend_forked
+          client.migration_variation("flag", context, LaunchDarkly::Migrations::STAGE_OFF)
+          expect(fork_warnings(logger).length).to eq(1)
+        end
+      end
+
+      it "warns on identify" do
+        with_client(test_config(logger: logger)) do |client|
+          pretend_forked
+          client.identify(context)
+          expect(fork_warnings(logger).length).to eq(1)
+        end
+      end
+
+      it "warns on track" do
+        with_client(test_config(logger: logger)) do |client|
+          pretend_forked
+          client.track("event", context)
+          expect(fork_warnings(logger).length).to eq(1)
+        end
+      end
+
+      it "warns on flush" do
+        with_client(test_config(logger: logger)) do |client|
+          pretend_forked
+          client.flush
+          expect(fork_warnings(logger).length).to eq(1)
+        end
+      end
+
+      it "warns on close" do
+        client = LDClient.new(sdk_key, test_config(logger: logger))
+        pretend_forked
+        client.close
+        expect(fork_warnings(logger).length).to eq(1)
+      end
+
+      it "warns only once per process across many calls" do
+        with_client(test_config(logger: logger)) do |client|
+          pretend_forked
+          5.times { client.variation("flag", context, false) }
+          client.identify(context)
+          client.track("event", context)
+          client.all_flags_state(context)
+          client.flush
+        end
+        expect(fork_warnings(logger).length).to eq(1)
+      end
+
+      it "warns only once when many threads evaluate at the same time" do
+        with_client(test_config(logger: logger)) do |client|
+          pretend_forked
+          threads = Array.new(16) do
+            Thread.new { 50.times { client.variation("flag", context, false) } }
+          end
+          threads.each(&:join)
+        end
+        expect(fork_warnings(logger).length).to eq(1)
+      end
+
+      it "names postfork and says flag updates and analytics events do not work" do
+        with_client(test_config(logger: logger)) do |client|
+          pretend_forked
+          client.variation("flag", context, false)
+        end
+        warning = fork_warnings(logger).first
+        expect(warning).to include("LDClient#postfork")
+        expect(warning).to include("flag updates and analytics events will not work")
+      end
+
+      it "warns in LDD mode when events are enabled" do
+        config = Config.new(use_ldd: true, send_events: true, logger: logger)
+        with_client(config) do |client|
+          pretend_forked
+          client.variation("flag", context, false)
+        end
+        expect(fork_warnings(logger).length).to eq(1)
+      end
+
+      it "does not warn in LDD mode when events are disabled" do
+        config = Config.new(use_ldd: true, send_events: false, logger: logger)
+        with_client(config) do |client|
+          pretend_forked
+          client.variation("flag", context, false)
+          client.flush
+        end
+        expect(fork_warnings(logger)).to be_empty
+      end
+
+      it "does not warn when offline" do
+        config = Config.new(offline: true, logger: logger)
+        with_client(config) do |client|
+          pretend_forked
+          client.variation("flag", context, false)
+          client.identify(context)
+          client.track("event", context)
+          client.all_flags_state(context)
+          client.flush
+        end
+        expect(fork_warnings(logger)).to be_empty
+      end
+
+      it "stops warning after postfork" do
+        with_client(test_config(logger: logger)) do |client|
+          pretend_forked
+          client.variation("flag", context, false)
+          expect(fork_warnings(logger).length).to eq(1)
+
+          client.postfork(0)
+          client.variation("flag", context, false)
+          client.flush
+        end
+        expect(fork_warnings(logger).length).to eq(1)
+      end
+
+      it "warns again in a second forked process even if the first one already warned" do
+        with_client(test_config(logger: logger)) do |client|
+          real_pid = Process.pid
+          allow(Process).to receive(:pid).and_return(real_pid + 1)
+          client.variation("flag", context, false)
+          expect(fork_warnings(logger).length).to eq(1)
+
+          # The "already warned" state is copied into a grandchild on fork. It must still warn there.
+          allow(Process).to receive(:pid).and_return(real_pid + 2)
+          client.variation("flag", context, false)
+          expect(fork_warnings(logger).length).to eq(2)
+        end
+      end
+    end
+
+    context "with a real fork" do
+      def fork_supported?
+        RUBY_ENGINE != "jruby" && Process.respond_to?(:fork)
+      end
+
+      it "warns in the child and stops after postfork" do
+        skip "fork is not supported on this platform" unless fork_supported?
+
+        client = LDClient.new(sdk_key, test_config(logger: logger))
+        begin
+          reader, writer = IO.pipe
+          pid = fork do
+            reader.close
+            child_logger = CapturingLogger.new
+            # Give the inherited client a fresh logger so the child output is easy to read.
+            client.instance_variable_get(:@config).instance_variable_set(:@logger, child_logger)
+
+            client.variation("flag", context, false)
+            client.variation("flag", context, false)
+            before_postfork = child_logger.output.lines.grep(warning_pattern).length
+
+            client.postfork(0)
+            client.variation("flag", context, false)
+            after_postfork = child_logger.output.lines.grep(warning_pattern).length
+
+            writer.write("#{before_postfork},#{after_postfork}")
+            writer.close
+            exit!(0)
+          end
+          writer.close
+          output = reader.read
+          reader.close
+          Process.wait(pid)
+
+          expect(output).to eq("1,1")
+          # The parent process was not forked, so it must not warn.
+          client.variation("flag", context, false)
+          expect(fork_warnings(logger)).to be_empty
+        ensure
+          client.close
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Ruby threads do not survive a fork. When an application builds `LDClient` before forking (for example Puma with `preload_app!` and workers > 1), each child inherits a client with no stream thread, no event dispatcher thread, no flush workers, and no timer tasks. In the child:

- `initialized?` stays true and the data source status stays `valid`, frozen at the parent's boot time.
- Flag values stay at the boot-time snapshot. Dashboard changes never arrive.
- Analytics events are never sent. The inbox fills and events are dropped.
- `close` blocks forever, because `EventProcessor#stop` waits for a dispatcher thread that does not exist.

The SDK gave no signal that anything was wrong. `LDClient#postfork` already fixes this, but a customer took two weeks to find it (support ticket #129534).

Jira: [SDK-3046](https://launchdarkly.atlassian.net/browse/SDK-3046)

## What this change does

- `LDClient` records `Process.pid` in the constructor and again in `postfork`.
- A private `check_forked` runs at the start of `variation`, `variation_detail`, `migration_variation`, `all_flags_state`, `identify`, `track`, `track_migration_op`, `flush`, and `close`. When the current pid differs from the recorded pid, it logs a WARN once per process:

  > [LDClient] This process was forked after the LDClient was created. Background threads do not survive a fork, so flag updates and analytics events will not work in this process. Call LDClient#postfork after forking.

- `flush` is now a real method instead of a `def_delegator` so it can run the check.
- The `postfork` YARD doc mentions the warning.

### When the warning is skipped

The check returns without warning in two configurations, because nothing breaks after a fork:

- `offline: true`. The client has no background threads.
- `use_ldd: true` with `send_events: false`. Flags are read from the persistent store on each evaluation and no events are sent.

Every other configuration gets the same static message.

### Design notes

- **Pid check instead of a `Process._fork` hook.** Each trigger compares `Process.pid` with the stored pid. `Process.pid` measured at about 27 ns per call (Ruby 4.0.6, macOS arm64), and the benchmark below shows no regression, so the simpler approach was kept. A `_fork` hook would also have to coexist with other libraries that override `_fork`.
- **"Already warned" is a pid, not a boolean.** The state is a `Concurrent::AtomicReference` holding the pid in which the warning was logged, updated with `compare_and_set`. A boolean would be copied into every child on fork, so a grandchild would inherit "already warned" and never get its own warning.
- **Warn only.** This change does not re-initialize the client automatically. `postfork` still has to be called by the application, and `close` in a forked child still blocks (the warning is logged before it blocks). Automatic re-initialization on fork detection is a possible follow-up.

## Test coverage

New `spec/ldclient_fork_spec.rb` (18 examples):

- No warning when the pid is unchanged.
- Warning on each trigger point with `Process.pid` stubbed.
- Exactly one warning across many calls and across 16 concurrent threads.
- The message names `postfork` and says flag updates and analytics events will not work.
- No warning in offline mode. No warning in LDD mode with events disabled. Warning in LDD mode with events enabled.
- `postfork` clears the condition.
- A second pid change (grandchild) warns again even though the first process already warned.
- One real `fork` test (skipped on JRuby or platforms without fork): the child logs one warning before `postfork` and none after; the parent never warns.

Full suite: `bundle exec rspec spec` passes with 1074 examples, 0 failures.

## Benchmark

`sdk-stress-tester --mode benchmark --passes 5` against the contract test service (60,000 evaluations per run, two runs each). Before is the unmodified 8.15.1 checkout.

| Run | p50 | p95 | p99 | evals/s (excl. warmup pass) |
|---|---|---|---|---|
| Before, run 1 | 200µs | 310µs | 608µs | 4,544 |
| Before, run 2 | 199µs | 284µs | 517µs | 4,728 |
| After, run 1 | 198µs | 297µs | 583µs | 4,662 |
| After, run 2 | 198µs | 276µs | 503µs | 4,731 |

The difference is within run-to-run noise.


[SDK-3046]: https://launchdarkly.atlassian.net/browse/SDK-3046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **fork detection** so apps that inherit an `LDClient` after `fork` (e.g. Puma `preload_app!`) get a clear signal instead of silently broken streams and events.
> 
> The client records **`Process.pid`** at construction and again in **`postfork`**. A private **`check_forked`** runs at the start of flag evaluation, identify/track, **`flush`**, and **`close`**. When the current pid differs from the owner, it logs a **one-time WARN** per process directing callers to **`LDClient#postfork`**. “Already warned” is tracked by **pid in an atomic reference** (not a boolean) so nested forks still warn. Warnings are **skipped** when **`offline`** or **LDD with events disabled**, where background threads are not required.
> 
> **`flush`** is implemented explicitly (replacing `def_delegator`) so it can run the fork check. **`postfork`** resets owner pid and warning state when re-initializing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d75753f1092633b79ea210f9a58d0465583b2246. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->