### PR TITLE
fix: Publish the data source status before releasing ready waiters

### DIFF
--- a/lib/ldclient-rb/impl/data_source/polling.rb
+++ b/lib/ldclient-rb/impl/data_source/polling.rb
@@ -38,14 +38,20 @@ module LaunchDarkly
           begin
             all_data, headers = request_all_data
             DataSource.record_environment_id(@config.data_source_update_sink, headers)
+            newly_initialized = false
             if all_data
               update_sink_or_data_store.init(all_data)
-              if @initialized.make_true
-                @config.logger.info { "[LDClient] Polling connection initialized" }
-                @ready.set
-              end
+              newly_initialized = @initialized.make_true
             end
             @config.data_source_update_sink&.update_status(LaunchDarkly::Interfaces::DataSource::Status::VALID, nil)
+
+            if newly_initialized
+              @config.logger.info { "[LDClient] Polling connection initialized" }
+              # Publish the VALID status before releasing anyone waiting on the
+              # ready event, so a client that returns from start can rely on the
+              # data source status already reflecting the successful poll.
+              @ready.set
+            end
           rescue JSON::ParserError => e
             @config.logger.error { "[LDClient] JSON parsing failed for polling response." }
             error_info = LaunchDarkly::Interfaces::DataSource::ErrorInfo.new(

--- a/lib/ldclient-rb/impl/data_system/fdv2.rb
+++ b/lib/ldclient-rb/impl/data_system/fdv2.rb
@@ -473,14 +473,16 @@ module LaunchDarkly
               # Handle the update
               @store.apply(update.change_set, true) if update.change_set
 
-              # Set ready event on valid update
-              if update.state == LaunchDarkly::Interfaces::DataSource::Status::VALID
-                @ready_event.set
-                record_environment_id(update.environment_id)
-              end
+              valid = update.state == LaunchDarkly::Interfaces::DataSource::Status::VALID
+              record_environment_id(update.environment_id) if valid
 
               # Update status
               @data_source_status_provider.update_status(update.state, update.error)
+
+              # Publish the status before releasing anyone waiting on the ready
+              # event, so a client that returns from start can rely on the data
+              # source status already reflecting the update.
+              @ready_event.set if valid
 
               return SyncResult::FDV1 if update.fallback_to_fdv1
 

--- a/spec/impl/data_source/polling_spec.rb
+++ b/spec/impl/data_source/polling_spec.rb
@@ -78,8 +78,11 @@ module LaunchDarkly
           expect(store.get(Impl::DataStore::FEATURES, "flagkey")).to eq(flag)
           expect(store.get(Impl::DataStore::SEGMENTS, "segkey")).to eq(segment)
 
-          expect(listener.statuses.count).to eq(1)
-          expect(listener.statuses[0].state).to eq(Interfaces::DataSource::Status::VALID)
+          # The poll thread sets the ready event before it publishes the VALID
+          # status, so wait for the listener to receive it.
+          statuses = listener.wait_for_status
+          expect(statuses.count).to eq(1)
+          expect(statuses[0].state).to eq(Interfaces::DataSource::Status::VALID)
         end
       end
     end
@@ -166,9 +169,13 @@ module LaunchDarkly
           expect(finished).to be false
           expect(processor.initialized?).to be false
 
-          expect(listener.statuses.count).to eq(2)
+          # The ready event is never set for a recoverable error, so the wait
+          # above only passes time. Wait for the poll thread to publish the
+          # INTERRUPTED status before asserting on it.
+          statuses = listener.wait_for_count(2)
+          expect(statuses.count).to eq(2)
 
-          s = listener.statuses[1]
+          s = statuses[1]
           expect(s.state).to eq(Interfaces::DataSource::Status::INTERRUPTED)
           expect(s.last_error.status_code).to eq(status)
         end

--- a/spec/impl/data_source/polling_spec.rb
+++ b/spec/impl/data_source/polling_spec.rb
@@ -78,11 +78,27 @@ module LaunchDarkly
           expect(store.get(Impl::DataStore::FEATURES, "flagkey")).to eq(flag)
           expect(store.get(Impl::DataStore::SEGMENTS, "segkey")).to eq(segment)
 
-          # The poll thread sets the ready event before it publishes the VALID
-          # status, so wait for the listener to receive it.
-          statuses = listener.wait_for_status
-          expect(statuses.count).to eq(1)
-          expect(statuses[0].state).to eq(Interfaces::DataSource::Status::VALID)
+          expect(listener.statuses.count).to eq(1)
+          expect(listener.statuses[0].state).to eq(Interfaces::DataSource::Status::VALID)
+        end
+      end
+
+      it 'publishes the valid status before releasing ready waiters' do
+        allow(requestor).to receive(:request_all_data).and_return(all_data)
+        store = InMemoryFeatureStore.new
+        with_processor(store) do |processor|
+          # The broadcaster notifies listeners inline on the poll thread, so a
+          # listener that sees the ready event already set proves the status was
+          # published too late.
+          ready = processor.instance_variable_get(:@ready)
+          ready_set_when_notified = nil
+          status_broadcaster.add_listener(CallbackListener.new(->(_status) { ready_set_when_notified = ready.set? }))
+
+          config = processor.instance_variable_get(:@config)
+          processor.start.wait
+
+          expect(ready_set_when_notified).to be false
+          expect(config.data_source_update_sink.current_status.state).to eq(Interfaces::DataSource::Status::VALID)
         end
       end
     end

--- a/spec/impl/data_system/fdv2_datasystem_spec.rb
+++ b/spec/impl/data_system/fdv2_datasystem_spec.rb
@@ -697,6 +697,25 @@ module LaunchDarkly
             FDv2.new(sdk_key, LaunchDarkly::Config.new(logger: logger), data_system_config)
           end
         end
+
+        describe "data source status" do
+          it "publishes the valid status before releasing ready waiters" do
+            td = LaunchDarkly::Integrations::TestDataV2.data_source
+            td.update(td.flag("flagkey").on(true))
+
+            data_system_config = LaunchDarkly::DataSystem::ConfigBuilder.new
+              .synchronizers([td.test_data_ds_builder])
+              .build
+
+            fdv2 = FDv2.new(sdk_key, config, data_system_config)
+
+            ready_event = fdv2.start
+            expect(ready_event.wait(2)).to be true
+            expect(fdv2.data_source_status_provider.status.state).to eq(LaunchDarkly::Interfaces::DataSource::Status::VALID)
+
+            fdv2.stop
+          end
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,15 +37,66 @@ class CallbackListener
   end
 end
 
+#
+# A test listener that records every event it receives.
+#
+# A data source can deliver events from its own thread. A spec that starts a
+# data source and then reads `statuses` at once can run before the event
+# arrives. Use `wait_for_count` or `wait_for_status` to block until the events
+# you expect have arrived, then assert on the returned array.
+#
 class ListenerSpy
-  attr_reader :statuses
-
   def initialize
+    @mutex = Mutex.new
+    @condition = ConditionVariable.new
     @statuses = []
   end
 
+  #
+  # Returns a copy of the events received so far.
+  #
+  # @return [Array]
+  #
+  def statuses
+    @mutex.synchronize { @statuses.dup }
+  end
+
   def update(status)
-    @statuses << status
+    @mutex.synchronize do
+      @statuses << status
+      @condition.broadcast
+    end
+  end
+
+  #
+  # Blocks until at least `count` events have arrived, or until the timeout
+  # passes. Returns a copy of the events received so far. The caller must
+  # still assert on the result; this method does not fail on timeout.
+  #
+  # @param count [Integer] the number of events to wait for
+  # @param timeout [Numeric] the maximum time to wait, in seconds
+  # @return [Array]
+  #
+  def wait_for_count(count, timeout: 2)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    @mutex.synchronize do
+      while @statuses.count < count
+        remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        break if remaining <= 0
+        @condition.wait(@mutex, remaining)
+      end
+      @statuses.dup
+    end
+  end
+
+  #
+  # Blocks until at least one event has arrived, or until the timeout passes.
+  #
+  # @param timeout [Numeric] the maximum time to wait, in seconds
+  # @return [Array]
+  #
+  def wait_for_status(timeout: 2)
+    wait_for_count(1, timeout: timeout)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,8 +42,8 @@ end
 #
 # A data source can deliver events from its own thread. A spec that starts a
 # data source and then reads `statuses` at once can run before the event
-# arrives. Use `wait_for_count` or `wait_for_status` to block until the events
-# you expect have arrived, then assert on the returned array.
+# arrives. Use `wait_for_count` to block until the events you expect have
+# arrived, then assert on the returned array.
 #
 class ListenerSpy
   def initialize
@@ -87,16 +87,6 @@ class ListenerSpy
       end
       @statuses.dup
     end
-  end
-
-  #
-  # Blocks until at least one event has arrived, or until the timeout passes.
-  #
-  # @param timeout [Numeric] the maximum time to wait, in seconds
-  # @return [Array]
-  #
-  def wait_for_status(timeout: 2)
-    wait_for_count(1, timeout: timeout)
   end
 end
 


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Follows #429, which fixed the same ordering problem on the unrecoverable-error path. Reworked from a spec-only change after @kinyoklion pointed out that the ordering itself was the bug — matching the change he has already merged in the Go SDK.

**Describe the solution you've provided**

*1. Publish the status before releasing ready waiters*

`PollingProcessor#poll` set the ready event and only then published `VALID`. A caller that returned from `start` could read a `data_source_status_provider.status` that still said `INITIALIZING` even though the poll had succeeded and the flags were already in the store. The FDv2 synchronizer loop had the same ordering.

Both now publish the status first and set the ready event afterwards. This is the same argument #429 made for the `OFF` path, applied to the success path.

*2. The success spec no longer needs to wait*

This PR started as a spec-only fix that waited for the listener to be notified. With the ordering corrected that wait is unnecessary, so `status is set to valid when data is received` is back to its original form, unchanged from `main`.

Worth correcting one claim from the original description: delivery here is not asynchronous. The polling spec uses `SynchronousExecutor`, whose `post` just yields, so `Broadcaster#broadcast` calls `listener.update` inline. The distinction is *which thread* — inline on the poll thread, not the spec thread. That is why the old ordering was racy and why the new ordering makes the assertion deterministic: by the time `@ready.set` runs, the listener has already returned on that same thread.

*3. The recoverable-error spec still needs its wait*

`verify_recoverable_http_error` (408, 429, 503) keeps `wait_for_count(2)`. That path publishes `INTERRUPTED` and never sets the ready event, so there is no event to reorder and the pre-existing `ready.wait(1)` was only passing time. `ListenerSpy`'s mutex and condition variable stay for the same reason — without an event there is no happens-before for the cross-thread read, and a bare array appended from the poll thread and read from the spec thread is a real data race on JRuby.

`wait_for_status` is removed; `wait_for_count` is the only helper still used.

**Describe alternatives you've considered**

Keeping the spec-only fix. It would have made CI green while leaving an observable ordering problem in the SDK, which is the same trade #429 declined.

Fixing the FDv2 *initializer* path as well. On success it sets the ready event and publishes no status at all — the status stays `INITIALIZING` until the synchronizer's first update lands. That looks like a larger bug than the ordering one and is worth its own discussion, so it is deliberately not touched here.

**Additional context**

The broader problem is that listeners can only be registered after the constructor returns, so the initial status broadcast is unobservable no matter which order these two lines run in — and `UpdateSink#update_status` drops a repeat of the same state, so it is never replayed. The reliable pattern is subscribe, then read `data_source_status_provider.status`. Separating `start` from construction would remove the question entirely; that is being discussed separately.

The new polling spec is a genuine regression guard — it fails deterministically without the production change, because it asserts that the listener does not observe an already-set ready event. The FDv2 spec is a contract assertion rather than a guard: it passes either way on CRuby, since the GIL hides the window there, and the FDv2 status broadcaster uses a real thread pool so a listener-ordering assertion would itself be racy.

The FDv2 `sleep` flake called out in the original description is now fixed on `main` by #432.

**Validation**

- Full local suite: 1084 examples, 0 failures. The gap against CI is the redis, dynamodb, and consul store specs, which need backing services.
- `polling_spec.rb` + `fdv2_datasystem_spec.rb` in a loop, 15 runs: 15 of 15 passed.
- New polling spec against the old ordering: fails, as intended.
- RuboCop clean on all five changed files.
