### PR TITLE
fix: Stop repeating tasks promptly instead of waiting out the sleep

### DIFF
--- a/lib/ldclient-rb/impl/repeating_task.rb
+++ b/lib/ldclient-rb/impl/repeating_task.rb
@@ -4,22 +4,39 @@ require "concurrent/atomics"
 
 module LaunchDarkly
   module Impl
+    #
+    # Runs a task again and again on a worker thread, with a fixed interval
+    # between runs.
+    #
+    # The worker waits on an event instead of calling `sleep`, so `stop` can
+    # wake it at once even if `stop` runs before the worker starts waiting.
+    #
+    # @private
+    #
     class RepeatingTask
       attr_reader :name
 
+      #
+      # @param interval [Numeric] seconds between the start of one run and the start of the next
+      # @param start_delay [Numeric, nil] seconds to wait before the first run
+      # @param task [Proc] the code to run
+      # @param logger [Logger]
+      # @param name [String] the name given to the worker thread
+      #
       def initialize(interval, start_delay, task, logger, name)
         @interval = interval
         @start_delay = start_delay
         @task = task
         @logger = logger
         @stopped = Concurrent::AtomicBoolean.new(false)
+        @stop_event = Concurrent::Event.new
         @worker = nil
         @name = name
       end
 
       def start
         @worker = Thread.new do
-          sleep(@start_delay) unless @start_delay.nil? || @start_delay == 0
+          @stop_event.wait(@start_delay) unless @start_delay.nil? || @start_delay == 0
 
           until @stopped.value do
             started_at = Time.now
@@ -29,19 +46,23 @@ module LaunchDarkly
               Impl::Util.log_exception(@logger, "Uncaught exception from repeating task", e)
             end
             delta = @interval - (Time.now - started_at)
-            if delta > 0
-              sleep(delta)
-            end
+            @stop_event.wait(delta) if delta > 0
           end
         end
 
         @worker.name = @name
       end
 
+      #
+      # Stops the worker thread and waits for it to finish.
+      #
+      # This method is safe to call more than once, before `start`, and from
+      # inside the task itself.
+      #
       def stop
         if @stopped.make_true
+          @stop_event.set
           if @worker && @worker.alive? && @worker != Thread.current
-            @worker.run  # causes the thread to wake up if it's currently in a sleep
             @worker.join
           end
         end

--- a/spec/impl/repeating_task_spec.rb
+++ b/spec/impl/repeating_task_spec.rb
@@ -59,6 +59,79 @@ module LaunchDarkly
         expect(no_more_items).to be true
       end
 
+      it "stops promptly when stopped during a long start delay" do
+        ran = Concurrent::Event.new
+        task = RepeatingTask.new(10, 10, -> { ran.set }, null_logger, "test")
+        task.start
+        started_at = Time.now
+        task.stop
+        elapsed = Time.now - started_at
+
+        expect(elapsed).to be < 1
+        expect(ran.set?).to be false
+      end
+
+      it "stops promptly when stopped while waiting between runs" do
+        ran = Concurrent::Event.new
+        task = RepeatingTask.new(10, 0, -> { ran.set }, null_logger, "test")
+        begin
+          task.start
+          expect(ran.wait(1)).to be true
+          started_at = Time.now
+          task.stop
+          elapsed = Time.now - started_at
+
+          expect(elapsed).to be < 1
+        ensure
+          task.stop
+        end
+      end
+
+      it "can be stopped before it is started" do
+        task = RepeatingTask.new(0.01, 0, -> {}, null_logger, "test")
+
+        expect { task.stop }.not_to raise_error
+      end
+
+      it "does not run the task if stopped before it is started" do
+        ran = Concurrent::Event.new
+        task = RepeatingTask.new(0.01, 0, -> { ran.set }, null_logger, "test")
+        task.stop
+        task.start
+        begin
+          expect(ran.wait(0.1)).to be false
+        ensure
+          task.stop
+        end
+      end
+
+      it "can be stopped more than once" do
+        task = RepeatingTask.new(10, 0, -> {}, null_logger, "test")
+        task.start
+        task.stop
+
+        expect { task.stop }.not_to raise_error
+      end
+
+      it "keeps running after the task raises an exception" do
+        queue = Queue.new
+        calls = 0
+        task = RepeatingTask.new(0.01, 0,
+          -> {
+            calls += 1
+            queue << calls
+            raise "boom" if calls == 1
+          },
+          null_logger, "test")
+        begin
+          task.start
+          expect(queue.pop).to eq(1)
+          expect(queue.pop).to eq(2)
+        ensure
+          task.stop
+        end
+      end
+
       it "can be stopped from within the task" do
         counter = 0
         stopped = Concurrent::Event.new


### PR DESCRIPTION
## Problem

`LaunchDarkly::Impl::RepeatingTask#stop` had a lost wake-up. The worker thread called `sleep(@start_delay)` before the first run and `sleep(delta)` between runs. `stop` set an atomic flag, called `Thread#run` to interrupt the sleep, then joined the worker.

`Thread#run` only wakes a thread that is already asleep. If the worker had been created but had not yet reached its `sleep`, the wake-up was lost and `join` blocked for the full sleep. On MRI, start then immediate stop with a 10 second start delay took 10.00 seconds in 5 of 5 runs. JRuby thread start-up is slower, so the window is wider there.

## Effect

**User-facing.** `LDClient#close` can stall for the start delay or the interval of any repeating task when it is called shortly after start. Under FDv2, `fdv2.rb` creates a `RepeatingTask.new(10, 10, ...)` per synchronizer and stops it in an `ensure` as soon as the synchronizer returns. When a synchronizer returns quickly, FDv2 stalls 10 seconds before it moves to the next synchronizer.

**CI.** The stall makes the JRuby job flaky on several `spec/impl/data_system/fdv2_datasystem_spec.rb` examples, such as "shuts down data source when both primary and secondary fail" (waits 5s for OFF) and "does not fall back to FDv1 when fallback_to_fdv1 is false" (waits 2s for ready). Seen on PRs #430 and #431 and on `main`.

PR #431 fixes a separate, spec-only race in the polling specs. It does not overlap with this change.

## Fix

The worker now waits on a `Concurrent::Event` instead of calling `sleep`. `stop` sets the event and then joins the worker. A wait on an event that is already set returns at once, so the wake-up cannot be lost no matter when `stop` runs relative to the worker.

The public interface is unchanged: `initialize(interval, start_delay, task, logger, name)`, `start`, `stop`, `name`. `stop` is still idempotent, still safe to call before `start` and from inside the task, and exceptions from the task are still logged without killing the loop. No call sites changed.

## Tests

New examples in `spec/impl/repeating_task_spec.rb`:

- start with a 10 second start delay, stop at once, assert `stop` returns in under 1 second and the task never ran
- start with interval 10 and delay 0, let the task run once, then stop and assert `stop` returns in under 1 second
- `stop` before `start` does not raise
- `stop` before `start` prevents the task from running
- `stop` called twice does not raise
- the loop keeps running after the task raises

The first new example fails against the old code (10.01 seconds) and passes with the fix. Full suite: 1062 examples, 0 failures on MRI. `fdv2_datasystem_spec.rb` looped 20 times with 0 failures. JRuby is not installed locally, so the JRuby CI job is the check for that runtime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes a **lost wake-up** in `RepeatingTask#stop` where `Thread#run` could miss a worker that had not entered `sleep` yet, so shutdown blocked for the full start delay or interval.
> 
> The worker now uses **`Concurrent::Event#wait`** for the initial delay and between runs; **`stop` sets the event** and joins, so shutdown is immediate regardless of timing. **`Thread#run` is removed.** Behavior and the public API stay the same (idempotent `stop`, safe before `start` and from inside the task).
> 
> Specs add coverage for prompt stop during long delays, stop-before-start, double stop, and continued looping after task exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533a80e98bf29611ddaa75c476550f69722c3d27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->