### PR TITLE
fix: Log the cached-data evaluation warning only once per client

### DIFF
--- a/lib/ldclient-rb/ldclient.rb
+++ b/lib/ldclient-rb/ldclient.rb
@@ -81,6 +81,10 @@ module LaunchDarkly
       # The pid of the process in which the fork warning was last logged, or nil.
       @fork_warned_pid = Concurrent::AtomicReference.new(nil)
 
+      # Each flag lets the matching cached-data warning log once per client.
+      @cached_data_evaluation_warned = Concurrent::AtomicBoolean.new(false)
+      @cached_data_all_flags_warned = Concurrent::AtomicBoolean.new(false)
+
       start_up(wait_for_sec)
     end
 
@@ -629,7 +633,9 @@ module LaunchDarkly
 
       unless initialized?
         if @data_system.store.initialized?
-            @config.logger.warn { "Called all_flags_state before client initialization; using last known values from data store" }
+          if @cached_data_all_flags_warned.make_true
+            @config.logger.warn { "Called all_flags_state before client initialization; using last known values from data store. This message is logged once." }
+          end
         else
             @config.logger.warn { "Called all_flags_state before client initialization. Data store not available; returning empty state" }
             return FeatureFlagsState.new(false)
@@ -765,7 +771,9 @@ module LaunchDarkly
 
       if @data_system.data_availability != Impl::DataSystem::DataAvailability::REFRESHED
         if @data_system.data_availability == Impl::DataSystem::DataAvailability::CACHED
-          @config.logger.warn { "[LDClient] Client has not finished initializing; using last known values from feature store" }
+          if @cached_data_evaluation_warned.make_true
+            @config.logger.warn { "[LDClient] Client has not finished initializing; using last known values from feature store. This message is logged once." }
+          end
         else
           @config.logger.error { "[LDClient] Client has not finished initializing; feature store unavailable, returning default value" }
           detail = Evaluator.error_result(EvaluationReason::ERROR_CLIENT_NOT_READY, default)

--- a/spec/ldclient_cached_data_warning_spec.rb
+++ b/spec/ldclient_cached_data_warning_spec.rb
@@ -1,0 +1,82 @@
+require "capturing_logger"
+require "mock_components"
+require "spec_helper"
+
+module LaunchDarkly
+  describe "LDClient cached-data warnings" do
+    let(:logger) { CapturingLogger.new }
+    let(:context) { basic_context }
+
+    # A data source that starts but never reports initialized. With a store that already holds
+    # data, the client evaluates with cached data.
+    def uninitialized_source
+      wait = double
+      allow(wait).to receive(:wait)
+      source = double
+      allow(source).to receive(:start).and_return(wait)
+      allow(source).to receive(:stop)
+      allow(source).to receive(:initialized?).and_return(false)
+      source
+    end
+
+    def initialized_store
+      store = InMemoryFeatureStore.new
+      store.init({ Impl::DataStore::FEATURES => {}, Impl::DataStore::SEGMENTS => {} })
+      store
+    end
+
+    def cached_data_config
+      test_config(logger: logger, feature_store: initialized_store, data_source: uninitialized_source)
+    end
+
+    def evaluation_warnings(logger)
+      logger.output.lines.grep(/Client has not finished initializing; using last known values/)
+    end
+
+    def all_flags_state_warnings(logger)
+      logger.output.lines.grep(/Called all_flags_state before client initialization; using last known values/)
+    end
+
+    it "logs the evaluation warning once per client" do
+      with_client(cached_data_config) do |client|
+        client.variation("flag", context, false)
+        client.variation("flag", context, false)
+        client.variation_detail("flag", context, false)
+        expect(evaluation_warnings(logger).length).to eq(1)
+      end
+    end
+
+    # all_flags_state checks LDClient#initialized?, which is true when the store holds data. The
+    # stub makes the client report not initialized so the cached-data branch runs.
+    it "logs the all_flags_state warning once per client" do
+      with_client(cached_data_config) do |client|
+        allow(client).to receive(:initialized?).and_return(false)
+        client.all_flags_state(context)
+        client.all_flags_state(context)
+        expect(all_flags_state_warnings(logger).length).to eq(1)
+      end
+    end
+
+    it "logs the evaluation and all_flags_state warnings independently" do
+      with_client(cached_data_config) do |client|
+        allow(client).to receive(:initialized?).and_return(false)
+        client.variation("flag", context, false)
+        client.all_flags_state(context)
+        client.variation("flag", context, false)
+        client.all_flags_state(context)
+        expect(evaluation_warnings(logger).length).to eq(1)
+        expect(all_flags_state_warnings(logger).length).to eq(1)
+      end
+    end
+
+    it "logs the warning again for a new client" do
+      with_client(cached_data_config) do |client|
+        client.variation("flag", context, false)
+      end
+      with_client(cached_data_config) do |client|
+        client.variation("flag", context, false)
+      end
+      expect(evaluation_warnings(logger).length).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

While data availability is CACHED (the store holds data but the client has not finished initializing), the SDK logs "using last known values" on every evaluation. A client that runs for a long time in that state floods the log with one warning per evaluation.

Each of the two messages (evaluation and `all_flags_state`) now logs once per `LDClient` instance. The guard is a `Concurrent::AtomicBoolean` checked with `make_true` (a compare-and-set, no lock), the same pattern the context filter uses for its non-symbol attribute warning. The check runs only inside the cached-data branch, so the normal evaluation path is unchanged. Each message now ends with "This message is logged once." to match that precedent. The sibling "store unavailable" messages and the gating conditions are unchanged.

New specs cover: one warning across repeated evaluations, one warning across repeated `all_flags_state` calls, the two messages counted independently, and a second client logging again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Stops **log flooding** when the client evaluates flags or builds `all_flags_state` while data is **CACHED** (store has values but initialization has not finished). Those “using last known values” warnings now emit **at most once per `LDClient`**, with separate one-shot flags for flag evaluation vs `all_flags_state`.
> 
> Guards use **`Concurrent::AtomicBoolean#make_true`** (same idea as other one-time SDK warnings). Wording adds **“This message is logged once.”**; **store-unavailable** errors and when evaluations actually use cached data are unchanged.
> 
> Adds specs for repeated calls, independent message types, and a fresh warning on a new client instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f673207f04d72368cd6fae2fe067d483acbf2207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->